### PR TITLE
SDK Examples Upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ See <https://nodejs.org/en/> and <https://classic.yarnpkg.com/en/docs/install> f
 
 > To run these examples, you will need to generate a sandboxed sdk key for your Matterport account. See [Matterport Developer Tools Pricing and Availability](https://support.matterport.com/hc/en-us/articles/360057506813-Matterport-Developer-Tools-Pricing-and-Availability).
 
-The password for the beta versions of bundle: gOJKDpxNiMCtdlnXs
+> You will need to insert your SDK Key into the following line in packages/common/src/index.ts:
+
+export const sdkKey = 'YOUR SDK KEY HERE';
+
 
 ### Setup monorepo root
 Run these two commands when you first download the repo.
@@ -37,7 +40,7 @@ Run these two commands when you first download the repo.
 > yarn install-bundle
 yarn run v1.22.4
 $ yarn fetch-bundle && yarn expand-bundle
-$ curl https://static.matterport.com/showcase-sdk/bundle/3.1.38.10-15-g5a5323ef0/showcase-bundle.zip -o bundle.zip
+$ curl https://static.matterport.com/showcase-sdk/bundle/24.2.1_webgl-99-g397d2e031f/showcase-bundle.zip -o bundle.zip
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100 3108k  100 3108k    0     0  7599k      0 --:--:-- --:--:-- --:--:-- 7599k
@@ -71,7 +74,7 @@ inspector: warning package.json: "inspector" is also the name of a node core mod
 inspector: $ webpack-dev-server
 inspector: ℹ ｢wds｣: Project is running at http://localhost:8000/
 inspector: ℹ ｢wds｣: webpack output is served from /
-inspector: ℹ ｢wds｣: Content not from webpack is served from /Users/bguillermo/projects/sdk_examples/packages/inspector
+inspector: ℹ ｢wds｣: Content not from webpack is served from /Users/[Username]/projects/sdk_examples/packages/inspector
 ```
 
 ### Run the virtual staging app
@@ -85,7 +88,7 @@ lerna info Executing command in 1 package: "yarn run develop"
 vs-app: $ webpack-dev-server
 vs-app: ℹ ｢wds｣: Project is running at http://localhost:8000/
 vs-app: ℹ ｢wds｣: webpack output is served from /
-vs-app: ℹ ｢wds｣: Content not from webpack is served from /Users/bguillermo/projects/sdk_examples/packages/vs-app
+vs-app: ℹ ｢wds｣: Content not from webpack is served from /Users/[Username]/projects/sdk_examples/packages/vs-app
 ```
 
 ### Run the magical bunny app
@@ -99,7 +102,7 @@ lerna info Executing command in 1 package: "yarn run develop"
 easter: $ webpack-dev-server
 easter: ℹ ｢wds｣: Project is running at http://localhost:8000/
 easter: ℹ ｢wds｣: webpack output is served from /
-easter: ℹ ｢wds｣: Content not from webpack is served from /Users/bguillermo/projects/sdk_examples/packages/easter
+easter: ℹ ｢wds｣: Content not from webpack is served from /Users/[Username]/projects/sdk_examples/packages/easter
 ```
 
 ### Run the remote control app
@@ -113,7 +116,7 @@ lerna info Executing command in 1 package: "yarn run develop"
 rc-app: $ webpack-dev-server
 rc-app: ℹ ｢wds｣: Project is running at http://localhost:8000/
 rc-app: ℹ ｢wds｣: webpack output is served from /
-rc-app: ℹ ｢wds｣: Content not from webpack is served from /Users/bguillermo/projects/sdk_examples/packages/rc-app
+rc-app: ℹ ｢wds｣: Content not from webpack is served from /Users/[Username]/projects/sdk_examples/packages/rc-app
 ```
 
 ### Run the embed sdk examples
@@ -129,7 +132,7 @@ embed-examples: warning package.json: No license field
 embed-examples: $ webpack-dev-server
 embed-examples: ℹ ｢wds｣: Project is running at http://localhost:8000/
 embed-examples: ℹ ｢wds｣: webpack output is served from /
-embed-examples: ℹ ｢wds｣: Content not from webpack is served from /Users/bguillermo/projects/sdk_examples/packages/embed-examples/dist
+embed-examples: ℹ ｢wds｣: Content not from webpack is served from /Users/[Username]/projects/sdk_examples/packages/embed-examples/dist
 ```
 
 ### Clean packages
@@ -139,14 +142,14 @@ You will need to bootstrap after cleaning.
 yarn run v1.21.1
 $ lerna clean --yes
 lerna notice cli v3.3.2
-lerna info clean removing /Users/bguillermo/projects/sdk_examples/packages/bundle/node_modules
-lerna info clean removing /Users/bguillermo/projects/sdk_examples/packages/common/node_modules
-lerna info clean removing /Users/bguillermo/projects/sdk_examples3/packages/core/node_modules
-lerna info clean removing /Users/bguillermo/projects/sdk_examples3/packages/easter/node_modules
-lerna info clean removing /Users/bguillermo/projects/sdk_examples2/packages/embed-examples/node_modules
-lerna info clean removing /Users/bguillermo/projects/sdk_examples/packages/inspector/node_modules
-lerna info clean removing /Users/bguillermo/projects/sdk_examples3/packages/rc-app/node_modules
-lerna info clean removing /Users/bguillermo/projects/sdk_examples/packages/vs-app/node_modules
+lerna info clean removing /Users/[Username]/projects/sdk_examples/packages/bundle/node_modules
+lerna info clean removing /Users/[Username]/projects/sdk_examples/packages/common/node_modules
+lerna info clean removing /Users/[Username]/projects/sdk_examples/packages/core/node_modules
+lerna info clean removing /Users/[Username]/projects/sdk_examples/packages/easter/node_modules
+lerna info clean removing /Users/[Username]/projects/sdk_examples/packages/embed-examples/node_modules
+lerna info clean removing /Users/[Username]/projects/sdk_examples/packages/inspector/node_modules
+lerna info clean removing /Users/[Username]/projects/sdk_examples/packages/rc-app/node_modules
+lerna info clean removing /Users/[Username]/projects/sdk_examples/packages/vs-app/node_modules
 lerna success clean finished
 ✨  Done in 5.11s.
 ```

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "decompress-cli": "^2.0.0",
     "ts-loader": "^9.3.0",
     "typescript": "^4.7.3",
-
     "webpack-cli": "^4.10.0",
     "webpack": "^5.73.0",
     "webpack-dev-server": "^4.9.2",
@@ -19,8 +18,8 @@
     "css-loader": "^6.7.1",
     "style-loader": "^3.3.1",
 
-    "three": "^0.139.2",
-    "@types/three": "^0.139.0",
+    "three": "^0.151.3",
+    "@types/three": "^0.151.0",
     "react": "^18.0.0",
     "@types/react": "^18.0.0",
     "react-dom": "^18.0.0",
@@ -38,6 +37,7 @@
     "easter": "lerna run develop --scope=easter --stream",
     "rc-app": "lerna run develop --scope=rc-app --stream",
     "embed-examples": "lerna run develop --scope=embed-examples --stream",
+    "training-tags-demo": "lerna run develop --scope=training-tags-demo --stream",
 
     "fetch-bundle": "cross-var curl https://static.matterport.com/showcase-sdk/bundle/$npm_package_config_bundle_version/showcase-bundle.zip -o bundle.zip",
     "expand-bundle": "yarn decompress bundle.zip --out-dir=./packages/bundle",
@@ -48,6 +48,6 @@
     "packages/*"
   ],
   "config": {
-    "bundle_version": "3.1.75.3-0-gba9de22f6d"
+    "bundle_version": "24.2.1_webgl-99-g397d2e031f"
   }
 }

--- a/packages/common/src/sdk-components/Camera/CameraRig.ts
+++ b/packages/common/src/sdk-components/Camera/CameraRig.ts
@@ -20,7 +20,7 @@ export class CameraRig extends Object3D {
     const focalRadius = camWorld.distanceTo(focalPoint);
 
     // when focusing, set the base's orientation ...
-    this.lookAt(focalPoint);
+    this.customLookAt(focalPoint);
     // ... remove any rotation from the camera itself ...
     this.camera.quaternion.set(0, 0, 0, 1);
     // ... and set the rig base at the focal point
@@ -40,7 +40,7 @@ export class CameraRig extends Object3D {
     this.updateMatrixWorld();
   }
 
-  lookAt(point: Vector3) {
+  customLookAt(point: Vector3) {
     // THREE.js's `lookAt` functions are lacking
     // THREE.js's `lookAt` branches between two different behaviors based on an `isCamera` and `isLight` boolean that is part of `Camera` and `Light`.
     // since this is a "camera", but only extends `Object3D`, AND because we support upside-down orientations, we have to use the underlying `Matrix4.lookAt`

--- a/packages/common/src/sdk-components/LoadingIndicator.ts
+++ b/packages/common/src/sdk-components/LoadingIndicator.ts
@@ -34,7 +34,7 @@ class LoadingIndicator extends SceneComponent {
       opacity: 0.2,
     });
     this.box = new THREE.Mesh(geometry, material);
-    this.mixer = new THREE.AnimationMixer(this.box);
+    //this.mixer = new THREE.AnimationMixer(this.box);
 
     for (const component of root.componentIterator()) {
       if (component.componentType === 'mp.gltfLoader') {
@@ -60,8 +60,10 @@ class LoadingIndicator extends SceneComponent {
       return;
     }
 
-    console.log(this.inputs.logo);
-    this.mixer = new THREE.AnimationMixer(this.inputs.logo);
+    // Must set a name to an object to use in a path
+    this.inputs.logo.children[0].children[0].name = 'logo';
+    // The OBJ is nested
+    this.mixer = new THREE.AnimationMixer(this.inputs.logo.children[0].children[0]);
 
     switch(this.inputs.loadingState) {
       case 'Idle':
@@ -89,7 +91,7 @@ class LoadingIndicator extends SceneComponent {
           action.play();
 
           const onEnterTime = this.inputs.transitionInDuration;
-          const opacityTrack = new THREE.NumberKeyframeTrack('.material.opacity', [0, onEnterTime], [0, 0.7], THREE.InterpolateSmooth);
+          const opacityTrack = new THREE.NumberKeyframeTrack('logo.material.opacity', [0, onEnterTime], [0, 0.7], THREE.InterpolateSmooth);
           const scaleTrack = new THREE.VectorKeyframeTrack('.scale', [0, onEnterTime],
             [0, 0, 0, this.inputs.size.x, this.inputs.size.y, this.inputs.size.z], THREE.InterpolateSmooth);
           const onEnterClip = new THREE.AnimationClip(null, onEnterTime, [opacityTrack, scaleTrack]);

--- a/packages/common/src/sdk-components/PlaneRenderer.ts
+++ b/packages/common/src/sdk-components/PlaneRenderer.ts
@@ -12,8 +12,8 @@ type Inputs = {
   polygonOffset: boolean;
   polygonOffsetFactor: number;
   polygonOffsetUnits: number;
-  localScale: {x: number; y: number; z: number; };
-  localPosition: {x: number; y: number; z: number; };
+  localScale: { x: number; y: number; z: number; };
+  localPosition: { x: number; y: number; z: number; };
 }
 
 export class PlaneRenderer extends SceneComponent implements IPlaneRenderer {
@@ -43,7 +43,7 @@ export class PlaneRenderer extends SceneComponent implements IPlaneRenderer {
     this.pivotNode = new THREE.Group();
 
     this.mesh = new THREE.Mesh(
-      new THREE.PlaneBufferGeometry(1.0, 1.0),
+      new THREE.PlaneGeometry(1.0, 1.0),
       new THREE.MeshBasicMaterial({
         transparent: this.inputs.transparent,
         map: this.inputs.texture,
@@ -56,7 +56,6 @@ export class PlaneRenderer extends SceneComponent implements IPlaneRenderer {
     this.mesh.position.set(this.inputs.localPosition.x, this.inputs.localPosition.y, this.inputs.localPosition.z);
     this.mesh.updateMatrixWorld();
     this.pivotNode.add(this.mesh);
-
     this.outputs.objectRoot = this.pivotNode;
     this.outputs.collider = this.pivotNode;
     this.mesh.visible = this.inputs.visible;

--- a/packages/common/src/sdk-components/ScenePainter.ts
+++ b/packages/common/src/sdk-components/ScenePainter.ts
@@ -21,14 +21,13 @@ class ScenePainterComponent extends SceneComponent {
     this.scene = new THREE.Scene();
     this.camera = new THREE.PerspectiveCamera();
     this.camera.position.z = 5;
-
     const cube = new THREE.Mesh(
-      new THREE.BoxBufferGeometry(1.0, 1.0, 1.0),
+      new THREE.BoxGeometry(1.0, 1.0, 1.0),
       new THREE.MeshBasicMaterial({
         color: 0x00ff00,
       }));
     const cubeEdges = new THREE.LineSegments(
-      new THREE.EdgesGeometry(new THREE.BoxBufferGeometry(1.0, 1.0, 1.0)),
+      new THREE.EdgesGeometry(new THREE.BoxGeometry(1.0, 1.0, 1.0)),
       new THREE.MeshBasicMaterial({
         color: 0x000000,
       }));
@@ -36,7 +35,7 @@ class ScenePainterComponent extends SceneComponent {
 
     const orbiter = new THREE.Object3D();
     const orbitCube = new THREE.Mesh(
-      new THREE.BoxBufferGeometry(0.4, 0.4, 0.4),
+      new THREE.BoxGeometry(0.4, 0.4, 0.4),
       new THREE.MeshBasicMaterial({
         color: 0xff00ff,
       }));
@@ -70,9 +69,9 @@ class ScenePainterComponent extends SceneComponent {
 }
 
 class ScenePainter implements IPainter3d {
-  constructor(private scene: Scene, private camera: Camera) {}
+  constructor(private scene: Scene, private camera: Camera) { }
 
-  paint(renderer: WebGLRenderer): void{
+  paint(renderer: WebGLRenderer): void {
     renderer.clear();
     renderer.render(this.scene, this.camera);
   }

--- a/packages/easter/src/react-components/MainView.tsx
+++ b/packages/easter/src/react-components/MainView.tsx
@@ -136,7 +136,8 @@ export class MainView extends Component<{}, State> {
       this.sdk.Scene.register(bunnyCaptureType, createBunnyCaptureClosure(gameState, eventBus, this.sdk)),
     ]);
 
-    const nodes = await this.sdk.Scene.deserialize(JSON.stringify(bunnies));
+    const object = await this.sdk.Scene.deserialize(JSON.stringify(bunnies));
+    const nodes = [...object.nodeIterator()];
 
     // set initial values of capture state
     gameState.captured.value = 0;

--- a/packages/easter/src/scene-components/BunnyCapture.ts
+++ b/packages/easter/src/scene-components/BunnyCapture.ts
@@ -1,14 +1,14 @@
 import { Dict } from '@mp/core';
 import { SceneEvents } from '../scenes/SceneEvents';
 import { SceneComponent } from '@mp/common';
-import { Camera, Vector3 } from 'three';
+import { PerspectiveCamera, Vector3 } from 'three';
 import { IGameState } from '../interfaces';
 import { Events } from 'phaser';
 
 class BunnyCaptureComponent extends SceneComponent {
   private cameraPose: any = null;
   private iframe: HTMLElement = null;
-  private projectionCam = new Camera();
+  private projectionCam = new PerspectiveCamera();
   private capturePoint = new Vector3();
 
   events = {
@@ -22,7 +22,6 @@ class BunnyCaptureComponent extends SceneComponent {
   onInit() {
     this.onCameraPoseChanged = this.onCameraPoseChanged.bind(this);
     this.iframe = document.getElementById('sdk-iframe');
-
     this.sdk.Camera.pose.subscribe(this.onCameraPoseChanged);
   }
 
@@ -52,10 +51,10 @@ class BunnyCaptureComponent extends SceneComponent {
       this.eventBus.emit(SceneEvents.StartRabbit, this.capturePoint);
 
       if (newCaptured >= this.gameState.total.value) {
-          const that = this;
-          setTimeout(function() {
-            that.eventBus.emit(SceneEvents.EndGame);
-          }, 2000);
+        const that = this;
+        setTimeout(function() {
+          that.eventBus.emit(SceneEvents.EndGame);
+        }, 2000);
       }
     }
   }

--- a/packages/embed-examples/examples/common/index.ejs
+++ b/packages/embed-examples/examples/common/index.ejs
@@ -1,42 +1,43 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0, shrink-to-fit=no"
+    />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="black-translucent"
+    />
+    <meta charset="UTF-8" />
+    <style>
+      body {
+        height: 100vh;
+        margin: 0px;
+        padding: 0px;
+        overflow: hidden;
+        font-family: "Roboto", sans-serif;
+        position: relative;
+      }
 
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport"
-    content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0, shrink-to-fit=no">
-  <meta name="mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-app-capable" content="yes" />
-  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-  <meta charset="UTF-8">
-  <style>
-    body {
-      height: 100vh;
-      margin: 0px;
-      padding: 0px;
-      overflow: hidden;
-      font-family: 'Roboto', sans-serif;
-      position: relative;
-    }
+      html {
+        height: 100vh;
+      }
 
-    html {
-      height: 100vh;
-    }
+      #content {
+        height: 100vh;
+        background-color: #dadada;
+      }
+    </style>
+    <script src="https://static.matterport.com/showcase-sdk/latest.js"></script>
+  </head>
 
-    #content {
-      height: 100vh;
-      background-color: #DADADA;
-    }
-  </style>
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="preload" as="style">
-  <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:400,700&display=swap" rel="preload" as="style">
-  <script src="https://static.matterport.com/showcase-sdk/2.0.1-0-g64e7e88/sdk.js"></script>
-</head>
-
-<body>
-  <iframe id="sdk-frame" allow="xr-spatial-tracking"></iframe>
-  <div id="text" class="hidden"></div>
-  <script type="text/javascript" src="./bundle.js"></script>
-</body>
-
+  <body>
+    <iframe id="sdk-frame" allow="xr-spatial-tracking"></iframe>
+    <div id="text" class="hidden"></div>
+    <script type="text/javascript" src="./bundle.js"></script>
+  </body>
 </html>

--- a/packages/embed-examples/examples/common/index.ts
+++ b/packages/embed-examples/examples/common/index.ts
@@ -7,7 +7,7 @@ declare global {
 }
 
 type ConnectOptions = {
-  urlParams?: {[key: string]: string};
+  urlParams?: { [key: string]: string };
 };
 
 export async function connect(options: ConnectOptions = {}): Promise<any> {
@@ -26,7 +26,7 @@ export async function connect(options: ConnectOptions = {}): Promise<any> {
     apiHost = urlParams.get('apiHost');
   }
 
-  for(const key in options.urlParams) {
+  for (const key in options.urlParams) {
     if (!urlParams.has(key)) {
       urlParams.set(key, options.urlParams[key]);
     }

--- a/packages/embed-examples/examples/common/sdk.d.ts
+++ b/packages/embed-examples/examples/common/sdk.d.ts
@@ -1,0 +1,4282 @@
+export type Vector2 = {
+	x: number;
+	y: number;
+};
+export type Vector3 = {
+	x: number;
+	y: number;
+	z: number;
+};
+export type Rotation = {
+	x: number;
+	y: number;
+	z?: number;
+};
+/**
+ * An orientation described with Euler-like angles in degrees.
+ */
+export type Orientation = {
+	yaw: number;
+	pitch: number;
+	roll: number;
+};
+export type Size = {
+	w: number;
+	h: number;
+};
+/**
+ * An RGB represenation of a color.
+ * Each property is normalized to the range [0, 1]
+ */
+export type Color = {
+	r: number;
+	g: number;
+	b: number;
+};
+/**
+ * An object representing an observer that is subscribed to an observable.
+ */
+export interface ISubscription {
+	/**
+	 * Removes the observer from the observable so that it stops receiving updates.
+	 */
+	cancel(): void;
+}
+/**
+ * A callback that can be subscribed to changes of an [[IObservable]]
+ *
+ * The functional style version of the [[IObserver]]
+ * @param <DataT> The type of the data being observed.
+ */
+export type ObserverCallback<DataT> = (data: DataT) => void;
+/**
+ * An observer that can be subscribed to changes of an [[IObservable]]
+ *
+ * The object-oriented version of the [[ObserverCallback]]
+ * @param <DataT> The type of the data being observed.
+ */
+export interface IObserver<DataT> {
+	/** Called when the data in the [[IObservable]] has changed. */
+	onChanged(data: DataT): void;
+}
+/**
+ * A callback that describes a condition of an [[IObservable]] to wait for.
+ * Returning true will resolve the promise returned by [[IObservable.waitUntil]]
+ *
+ * The functional style version of the [[ICondition]]
+ * @param <DataT> The type of the data to check conditions on.
+ */
+export type ConditionCallback<DataT> = (data: DataT) => boolean;
+/**
+ * An observer-like object that describes a condition to wait for on an [[IObservable]]
+ *
+ * The object-oriented version of the [[ConditionCallback]]
+ * @param <DataT> The type of the data to check conditions on.
+ */
+export interface ICondition<DataT> {
+	/**
+	 * Called when the data in the [[IObservable]] has changed.
+	 * Returning true will resolve the promise returned by [[IObservable.waitUntil]]
+	 */
+	waitUntil(data: DataT): boolean;
+}
+/**
+ * A data object that can have its changes observed via subscribing an [[IObserver]] or [[ObserverCallback]]
+ * @param <DataT> The type of the data being observed.
+ */
+export interface IObservable<DataT> {
+	/**
+	 * Subscribe to changes on this object.
+	 * When this observable detects a change, the `observer` provided will be called with the data associated with this observable.
+	 * @param observer
+	 * @returns {ISubscription} A subscription that can be used to remove the subscribed observer.
+	 */
+	subscribe(observer: IObserver<DataT> | ObserverCallback<DataT>): ISubscription;
+	/**
+	 * Wait for a specific condition on this object to be met.
+	 * When this observable detects a change, the `condition` provided will be called. When the `condition` returns true, the returned Promise will be resolved.
+	 * @param {ICondition | ConditionCallback} condition
+	 * @returns {Promise<void>} A promise that is resolved when `condition` returns true.
+	 */
+	waitUntil(condition: ICondition<DataT> | ConditionCallback<DataT>): Promise<void>;
+}
+/**
+ * An observer that can subscribe to changes of an [[IObservableMap]]
+ *
+ * @param <ItemT> The type of the items in the map.
+ */
+export interface IMapObserver<ItemT> {
+	/** Called when an item is added with the `index`, the new `item`, and current state of the `collection`. */
+	onAdded?(index: string, item: ItemT, collection: Dictionary<ItemT>): void;
+	/** Called when an item is removed, with the `index`, the removed `item`, and current state of the `collection`. */
+	onRemoved?(index: string, item: ItemT, collection: Dictionary<ItemT>): void;
+	/** Called when an existing item is altered, with the `index`, the new `item`, and current state of the `collection`. */
+	onUpdated?(index: string, item: ItemT, collection: Dictionary<ItemT>): void;
+	/**
+	 * Called when a set of changes happens within the `collection`.
+	 * For example, this can be used to get the initial state of the collection instead of receiving individual `onAdded` calls for each item.
+	 */
+	onCollectionUpdated?(collection: Dictionary<ItemT>): void;
+}
+/**
+ * A map that can have its changes observed via subscribing an [[IMapObserver]]
+ *
+ * For each observer subscribed to this `IObservableMap`:
+ * - `observer.onAdded` will be called when an item is added to the collection
+ * - `observer.onRemoved` will be called when an item is removed from the collection
+ * - `observer.onUpdated` will be called when an item has some of its properties changed
+ * - `observer.onCollectionUpdated` will be called when some set of the above events have occured (item added/removed/updated)
+ *
+ * When first subscribing, the observers' `onAdded` will be called for each item in the collection, and then again as items are added.
+ * Alternatively, the `onCollectionUpdated` will always give an up-to-date view of the collection.
+ * `onCollectionUpdated`, on first subscription, will be called once with the entire collection, and then again as changes to the collection  occur.
+ *
+ * @param <ItemT> The type of the items in the map being observed.
+ */
+export interface IObservableMap<ItemT> {
+	/**
+	 * Subscribe to changes in this map.
+	 * When this observable detects a change, the `observer` provided will have its `onAdded`, `onRemoved`, and/or `onUpdated` called.
+	 * @param observer
+	 * @returns {ISubscription} A subscription that can be used to remove the subscribed observer.
+	 */
+	subscribe(observer: IMapObserver<ItemT>): ISubscription;
+}
+/**
+ * A homogenous collection of items indexable by string like a standard JavaScript object.
+ * Can also be iterated with a `for..of` loop.
+ *
+ * @param <ItemT> The type of each item in this collection.
+ */
+export interface Dictionary<ItemT> {
+	/**
+	 * Iterate all items in the collection using `for..of`.
+	 * ```typescript
+	 * for (const [key, item] of collection) {
+	 *   console.log(`the collection contains ${item} at the index ${key}`);
+	 * }
+	 * ```
+	 */
+	[Symbol.iterator](): IterableIterator<[
+		string,
+		ItemT
+	]>;
+	/** Get an item using a specific `key`. */
+	[key: string]: ItemT;
+}
+/**
+ * An interface that is used to indicate that a resource or object is no longer needed.
+ */
+export interface IDisposable {
+	dispose(): void;
+}
+declare function disconnect(): void;
+export declare namespace App {
+	enum Event {
+		PHASE_CHANGE = "application.phasechange"
+	}
+	/**
+	 * Application phases are returned as part of the [[state]] observable.
+	 *
+	 * ```
+	 * mpSdk.App.state.subscribe(function (appState) {
+	 *  if(appState.phase === mpSdk.App.Phase.LOADING) {
+	 *    console.log('The app has started loading!')
+	 *  }
+	 *  if(appState.phase === mpSdk.App.Phase.STARTING) {
+	 *    console.log('The transition into the start location begins!')
+	 *  }
+	 *  if(appState.phase === mpSdk.App.Phase.PLAYING) {
+	 *    console.log('The app is ready to take user input now!')
+	 *  }
+	 * });
+	 * ```
+	 */
+	enum Phase {
+		UNINITIALIZED = "appphase.uninitialized",
+		WAITING = "appphase.waiting",
+		LOADING = "appphase.loading",
+		STARTING = "appphase.starting",
+		PLAYING = "appphase.playing",
+		ERROR = "appphase.error"
+	}
+	/**
+	 * Application
+	 */
+	enum Application {
+		UNKNOWN = "application.unknown",
+		WEBVR = "application.webvr",
+		SHOWCASE = "application.showcase",
+		WORKSHOP = "application.workshop"
+	}
+	/**
+	 * @deprecated This type is used by deprecated functionality. Use [[state]] observable.
+	 */
+	type AppState = {
+		application: Application;
+		phase: Phase;
+	};
+	type State = {
+		application: Application;
+		phase: Phase;
+		/**
+		 * An object whose keys are phases from [[Phase]]
+		 * and values are epoch time in milliseconds.
+		 * The times are filled in after the phase has passed.
+		 * ```
+		 * {
+		 *    phaseTimes: {
+		 *      'appphase.uninitialized': 1570084156590,
+		 *      'appphase.waiting': 0,
+		 *      'appphase.loading': 0,
+		 *      'appphase.starting': 0,
+		 *      'appphase.playing': 0,
+		 *      'appphase.error': 0,
+		 *    }
+		 * }
+		 * ```
+		 */
+		phaseTimes: {
+			[phase: string]: number;
+		};
+	};
+}
+export interface App {
+	Event: typeof App.Event;
+	Phase: typeof App.Phase;
+	Application: typeof App.Application;
+	/**
+	 * @deprecated Use [[state]] observable to get the current phase or application.
+	 */
+	getState(): Promise<App.AppState>;
+	/**
+	 * @deprecated Use [[state]] observable to get load times.
+	 */
+	getLoadTimes(): Promise<{
+		[key in App.Phase]: null | number;
+	}>;
+	/**
+	 * An observable application state object.
+	 *
+	 * ```
+	 * mpSdk.App.state.subscribe(function (appState) {
+	 *  // app state has changed
+	 *  console.log('The current application: ', appState.application);
+	 *  console.log('The current phase: ', appState.phase);
+	 *  console.log('Loaded at time ', appState.phaseTimes[mpSdk.App.Phase.LOADING]);
+	 *  console.log('Started at time ', appState.phaseTimes[mpSdk.App.Phase.STARTING]);
+	 * });
+	 *
+	 * output
+	 * > The current application: application.showcase
+	 * > The current phase: appphase.waiting
+	 * > Loaded at time 1570084156590
+	 * > Started at time 1570084156824
+	 * >
+	 * ```
+	 */
+	state: IObservable<App.State>;
+}
+export interface Asset {
+	/**
+	 * Register a texture to use with subsequent calls like [[Tag.editIcon]].
+	 *
+	 * **Note**: It is recommended to host your own images to mitigate cross origin limitations.
+	 *
+	 * ```
+	 * mpSdk.Asset.registerTexture('customTextureId', 'https://[link.to/image]');
+	 * ```
+	 *
+	 * @param id A user specified string to use as a lookup of this texture
+	 * @param iconSrc The src of the icon, like the src of an \<img>
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.68.12-7-g858688944a
+	 */
+	registerTexture(id: string, iconSrc: string): Promise<void>;
+}
+export declare namespace Mode {
+	enum Mode {
+		INSIDE = "mode.inside",
+		OUTSIDE = "mode.outside",
+		DOLLHOUSE = "mode.dollhouse",
+		FLOORPLAN = "mode.floorplan",
+		TRANSITIONING = "mode.transitioning"
+	}
+	enum Event {
+		/** @event */
+		CHANGE_START = "viewmode.changestart",
+		/** @event */
+		CHANGE_END = "viewmode.changeend"
+	}
+	type TransitionData = {
+		from: Mode | null;
+		to: Mode | null;
+	};
+	enum TransitionType {
+		INSTANT = "transition.instant",
+		FLY = "transition.fly",
+		FADEOUT = "transition.fade"
+	}
+	type MoveToModeOptions = {
+		rotation?: Rotation;
+		position?: Vector3;
+		transition?: TransitionType;
+		zoom?: number;
+	};
+	type CurrentViewmodeData = Mode | null;
+}
+export interface Mode {
+	Mode: typeof Mode.Mode;
+	Event: typeof Mode.Event;
+	TransitionType: typeof Mode.TransitionType;
+	/**
+	 * The current view mode.
+	 *
+	 * ```
+	 * mpSdk.Mode.current.subscribe(function (mode) {
+	 *   // the view mode has changed
+	 *   console.log('Current view mode is is ', mode);
+	 * });
+	 * ```
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.68.12-7-g858688944a
+	 */
+	current: IObservable<Mode.Mode | null>;
+	/**
+	 * Change the viewing mode in 3D Showcase.
+	 *
+	 *```
+	 * const mode = mpSdk.Mode.Mode.FLOORPLAN;
+	 * const position = {x: 0, y: 0, z: 0};
+	 * const rotation = {x: -90, y: 0};
+	 * const transition = mpSdk.Mode.TransitionType.FLY;
+	 * const zoom = 5;
+	 *
+	 * mpSdk.Mode.moveTo(mode, {
+	 *     position: position,
+	 *     rotation: rotation,
+	 *     transition: transition,
+	 *     zoom,
+	 *   })
+	 *   .then(function(nextMode){
+	 *     // Move successful.
+	 *     console.log('Arrived at new view mode ' + nextMode);
+	 *   })
+	 *   .catch(function(error){
+	 *     // Error with moveTo command
+	 *   });
+	 * ```
+	 *
+	 * Notes about transitions to Floorplan mode:
+	 * * `zoom` option is only taken into account in Floorplan transitions, the lower the number,
+	 *   the further the camera is zoomed in
+	 * * The position of a floorplan view is determined by the X and Z arguments of the optional position object.
+	 * * The rotation of a floorplan view is determined by the X and Y of the optional rotation object,
+	 *   changing X changes the 'roll' of the view, similar to hitting the LEFT/RIGHT arrow keys in Showcase
+	 *   floorplan view, changing the Y value has no analog in showcase, but changes the 'tilt' of the view.
+	 *
+	 * @param The mode.
+	 * @param Options object, containing optional position, rotation, transition type
+	 * @return A promise that resolves with the new mode once the mode has transitioned.
+	 */
+	moveTo(mode: Mode.Mode, options?: Mode.MoveToModeOptions): Promise<Mode.Mode>;
+	/**
+	 * An observable transition of the current viewmode. `from` and `to` will be null
+	 * if there is no active transition.
+	 *
+	 * ```
+	 * mpSdk.Mode.transition.subscribe(function (transition) {
+	 *   // the transition has changed
+	 *   console.log(transition.from, transition.to, transition.progress);
+	 * });
+	 * ```
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.68.12-7-g858688944a
+	 */
+	transition: IObservable<Mode.TransitionData>;
+}
+export declare namespace Camera {
+	type Pose = {
+		position: Vector3;
+		rotation: Vector2;
+		projection: Float32Array;
+		sweep: string;
+		mode: Mode.Mode;
+	};
+	enum Event {
+		/** @event */
+		MOVE = "camera.move"
+	}
+	enum Direction {
+		FORWARD = "FORWARD",
+		LEFT = "LEFT",
+		RIGHT = "RIGHT",
+		BACK = "BACK",
+		UP = "UP",
+		DOWN = "DOWN"
+	}
+	type RotateOptions = {
+		/**
+		 * Rotation speed in degrees per second.
+		 */
+		speed?: number;
+	};
+	type ZoomData = {
+		/**
+		 * The current zoom level
+		 */
+		level: number;
+	};
+}
+export interface Camera {
+	Event: typeof Camera.Event;
+	Direction: typeof Camera.Direction;
+	/**
+	 * Returns the current state of camera.
+	 * ```
+	 * mpSdk.Camera.getPose()
+	 *   .then(function(pose){
+	 *     console.log('Current position is ', pose.position);
+	 *     console.log('Rotation angle is ', pose.rotation);
+	 *     console.log('Sweep UUID is ', pose.sweep);
+	 *     console.log('View mode is ', pose.mode);
+	 *   });
+	 * ```
+	 * @return A promise that resolves with the current state of the camera.
+	 * @deprecated You can use the [[pose]] observable property instead.
+	 */
+	getPose(): Promise<Camera.Pose>;
+	/**
+	 * An observable pose data object that can be subscribed to.
+	 *
+	 * ```
+	 * mpSdk.Camera.pose.subscribe(function (pose) {
+	 *   // Changes to the Camera pose have occurred.
+	 *   console.log('Current position is ', pose.position);
+	 *   console.log('Rotation angle is ', pose.rotation);
+	 *   console.log('Sweep UUID is ', pose.sweep);
+	 *   console.log('View mode is ', pose.mode);
+	 * });
+	 * ```
+	 */
+	pose: IObservable<Camera.Pose>;
+	/**
+	 * Moves user to a different sweep relative to their current location
+	 *
+	 * ```
+	 * const nextDirection = mpSdk.Camera.Direction.FORWARD;
+	 *
+	 * mpSdk.Camera.moveInDirection(nextDirection)
+	 *   .then(function(){
+	 *     console.log('The camera has moved forward.');
+	 *   })
+	 *   .catch(function(){
+	 *     console.warning('An error occured while moving in that direction.');
+	 *   });
+	 * ```
+	 * @param direction The direction.
+	 * @return A promise that resolves when a sweep has been reached.
+	 *
+	 * **Errors**
+	 *
+	 * * Fails if direction is not one of the above options.
+	 * * Warns if you can’t move in that direction (hit a wall).
+	 *
+	 * **Notes**
+	 *
+	 * This is the same behavior as if the user presses the arrow keys while in 3D Showcase.
+	 *
+	 * * Camera.Direction.UP is like moving forwards
+	 * * Camera.Direction.DOWN is like moving backwards
+	 *
+	 * This action is for moving between sweeps while in Inside View.
+	 */
+	moveInDirection(direction: Camera.Direction): Promise<void>;
+	/**
+	 * Pans the camera.
+	 *
+	 * ```
+	 * mpSdk.Camera.pan({ x: 1, z: 1 })
+	 *   .then(function() {
+	 *     // Pan complete.
+	 *   })
+	 *   .catch(function(error) {
+	 *     // Pan error.
+	 *   });
+	 * ```
+	 *
+	 * @param params.x Absolute position of the sweep on the x axis.
+	 * @param params.z Absolute position of the sweep on the z axis.
+	 * @return A promise that resolves when the pan is complete.
+	 *
+	 * **Errors**
+	 *
+	 * * Warns if pan was successful but you hit the model bounds.
+	 * * Fails if you are already at the model bounds and you cannot move any further.
+	 *
+	 * **Notes**
+	 *
+	 * The orientation of the axes depends on the sweep you were in before entering
+	 * Floorplan and the aspect ratio of window.
+	 *
+	 * Only available in Dollhouse or Floorplan View. This is the same behavior as
+	 * if the user uses the keyboard shortcuts W, A, S, and D or the arrow keys.
+	 *
+	 * Use `mpSdk.Camera.pan({ x: 0, z: 0 });` to return to directly above the
+	 * very first sweep scanned.
+	 */
+	pan(params: {
+		x: number;
+		z: number;
+	}): Promise<void>;
+	/**
+	 * Rotates the camera (user’s viewpoint).
+	 *
+	 * ```
+	 * mpSdk.Camera.rotate(10, -20, { speed: 2 })
+	 *   .then(function() {
+	 *     // Camera rotation complete.
+	 *   })
+	 *   .catch(function(error) {
+	 *     // Camera rotation error.
+	 *   });
+	 * ```
+	 *
+	 * @param vertical How many degrees to rotate up or down.
+	 * @param horizontal How many degrees to rotate left or right.
+	 * @param options
+	 * @return A promise that resolves when the rotation is complete.
+	 *
+	 * **Errors**
+	 *
+	 * * Warns to console if you rotated, but then you hit the vertical limit.
+	 * * Warns if trying to rotate up or down in Floorplan View.
+	 * * Fails if no movement because you are already at a rotation limit.
+	 *
+	 * **Notes**
+	 *
+	 * If user is in Dollhouse or Floorplan View, the entire Matterport Space is rotated.
+	 * * Positive values for horizontal means the Space rotates clockwise.
+	 * * Negative values for horizontal counterclockwise rotations.
+	 * * In Dollhouse view, vertical ranges from 0° (horizontal) to 80° above the Space.
+	 * * In Floorplan view, the vertical value is ignored.
+	 *
+	 * If the user is in Inside View or 360º View, their viewpoint is rotated.
+	 * * Positive values for horizontal means the user rotates clockwise.
+	 * * Negative values for horizontal are counterclockwise rotations.
+	 * * Vertical ranges from -70° (down) to 70° (up).
+	 * * Tilting the view (similar to tilting one’s head) not supported.
+	 *
+	 * Rotation is relative to the user’s current viewpoint.
+	 * This is the same behavior as if the user uses the keyboard shortcuts I, J, K, and L.
+	 * Speeds less than or equal to zero are not allowed.
+	 */
+	rotate(horizontal: number, vertical: number, options?: Camera.RotateOptions): Promise<void>;
+	/**
+	 * Sets the orientation of the camera (user’s viewpoint) while in Panorama View.
+	 *
+	 * ```
+	 * mpSdk.Camera.setRotation({ x: 10, y: -20 }, { speed: 2 })
+	 *   .then(function() {
+	 *     // Camera rotation complete.
+	 *   })
+	 *   .catch(function(error) {
+	 *     // Camera rotation error.
+	 *   });
+	 * ```
+	 *
+	 * @param rotation The target rotation
+	 * @param options
+	 * @return A promise that resolves when the rotation is complete.
+	 *
+	 * **Errors**
+	 * * Fails if the current view mode is not Panorama View.
+	 *
+	 * **Notes**
+	 * * A target rotation can be retrieved from [[Camera.pose]]
+	 * * Rotation is absolute so multiple calls will not further change orientation (floating point error notwithstanding).
+	 * * Speeds less than or equal to zero are not allowed.
+	 */
+	setRotation(rotation: Rotation, options?: Camera.RotateOptions): Promise<void>;
+	/**
+	 * Rotates the camera to a specific screen coordinate.
+	 * Coordinates are measure in pixels, relative to the WebGL Canvas' top left corner.
+	 * See https://www.w3schools.com/graphics/canvas_coordinates.asp for more information on coordinates.
+	 *
+	 * ```
+	 * mpSdk.Camera.lookAtScreenCoords(500, 320)
+	 *   .then(function() {
+	 *     // Camera rotation complete.
+	 *   })
+	 *   .catch(function(error) {
+	 *     // Camera rotation error.
+	 *   });
+	 * ```
+	 *
+	 * @param {number} x Horizontal position, in pixels. Starting from the canvas' top left corner.
+	 * @param {number} y Vertical position, in pixels. Starting from the canvas' top left corner.
+	 * @returns {Promise<void>} A Promise that resolves when the rotation is complete.
+	 *
+	 * **Errors**
+	 * * Fails if used outside of Inside mode.
+	 * * Warns to console if you rotated, but then you hit the vertical limit.
+	 * * Fails if no movement because you are already at a rotation limit.
+	 */
+	lookAtScreenCoords(x: number, y: number): Promise<void>;
+	/**
+	 * Zooms the camera to a percentage of the base field of view.
+	 *
+	 * Ex: Doubling the zoom, halves the field of view.
+	 *
+	 * ```
+	 * mpSdk.Camera.zoomTo(2.0)
+	 *  .then(function (newZoom) {
+	 *    console.log('Camera zoomed to', newZoom);
+	 *  });
+	 * ```
+	 *
+	 * @param zoomLevel
+	 *
+	 * **Errors**
+	 * * Fails if the current mode is not Inside mode.
+	 * * Warns to console if the zoom level is outside of the zoom range supported.
+	 */
+	zoomTo(zoomLevel: number): Promise<number>;
+	/**
+	 * Zooms the camera by a percentage. The zoom delta is defined relative to the base field of view, not the current zoom.
+	 * This means that the delta is strictly added, and not multiplied by the current zoom first.
+	 *
+	 *
+	 * Ex: If at zoom 2.0, zooming by another 0.1x will bring the camera to 2.1x (2.0 + 0.1) not 2.2x (2.0 + 2.0 * 0.1)
+	 *
+	 * ```
+	 * mpSdk.Camera.zoomBy(0.1)
+	 *   .then(function (newZoom) {
+	 *     console.log('Camera zoomed to', newZoom);
+	 *   });
+	 * ```
+	 *
+	 * @param zoomDelta
+	 *
+	 * **Errors**
+	 * * Fails if the current mode is not Inside mode.
+	 * * Warns to console if the zoom level would be outside of the zoom range supported.
+	 */
+	zoomBy(zoomDelta: number): Promise<number>;
+	/**
+	 * Reset the zoom of the camera back to 1.0x.
+	 *
+	 * ```
+	 * mpSdk.Camera.zoomReset()
+	 *   .then(function () {
+	 *     console.log('Camera zoom has been reset');
+	 *   })
+	 * ```
+	 *
+	 * **Errors**
+	 * * Fails if the current mode is not Inside mode.
+	 */
+	zoomReset(): Promise<void>;
+	/**
+	 * An observable zoom level of the camera in Panorama mode.
+	 * The zoom level will be 1.0 for all other viewmodes.
+	 *
+	 * ```
+	 * mpSdk.Camera.zoom.subscribe(function (zoom) {
+	 *   // the zoom level has changed
+	 *   console.log('Current zoom is ', zoom.level);
+	 * });
+	 * ```
+	 */
+	zoom: IObservable<Camera.ZoomData>;
+}
+export declare namespace Conversion { }
+export interface Conversion {
+	/**
+	 * Converts a position of an object in 3d to the pixel coordinate on the screen
+	 *
+	 * @param worldPos Position of the object
+	 * @param cameraPose The current pose of the Camera as received from Camera.pose.subscribe
+	 * @param windowSize The current size of the Showcase player
+	 * @param result An optional, pre-allocated Vector3 to store the result
+	 *
+	 * ```
+	 * var showcase = document.getElementById('showcaseIframe');
+	 * var showcaseSize = {
+	 *  w: showcase.clientWidth,
+	 *  h: showcase.clientHeight,
+	 * };
+	 * var cameraPose; // get pose using: mpSdk.Camera.pose.subscribe
+	 * var mattertag; // get a mattertag from the collection using: mpSdk.Mattertag.getData
+	 *
+	 * var screenCoordinate = mpSdk.Conversion.worldToScreen(mattertag.anchorPosition, cameraPose, showcaseSize)
+	 * ```
+	 */
+	worldToScreen(worldPos: Vector3, cameraPose: Camera.Pose, windowSize: Size, result?: Vector3): Vector3;
+}
+export declare namespace Floor {
+	type Floors = {
+		currentFloor: number;
+		floorNames: string[];
+		totalFloors: number;
+	};
+	type FloorData = {
+		id: string;
+		sequence: number;
+		name: string;
+	};
+	type ObservableFloorData = {
+		id: string | undefined;
+		sequence: number | undefined;
+		name: string;
+	};
+	enum Event {
+		/** @event */
+		CHANGE_START = "floors.changestart",
+		/** @event */
+		CHANGE_END = "floors.changeend"
+	}
+	namespace Conversion {
+		/**
+		 * Generate a map between v2 IDs and v1 IDs
+		 *
+		 * This method will help with migration between IDs used for floors.
+		 *
+		 * ```
+		 * const mapping = await mpSdk.Floor.Conversion.createIdMap();
+		 * ```
+		 *
+		 * @param invert?: boolean - if passed, return map of v1->v2 instead
+		 */
+		function createIdMap(invert?: boolean): Promise<Dictionary<string>>;
+	}
+}
+export interface Floor {
+	Event: typeof Floor.Event;
+	Conversion: typeof Floor.Conversion;
+	/**
+	 * This function returns the state of all floors.
+	 *
+	 * ```
+	 * mpSdk.Floor.getData()
+	 *   .then(function(floors) {
+	 *     // Floor data retreival complete.
+	 *     console.log('Current floor: ' + floors.currentFloor);
+	 *     console.log('Total floos: ' + floors.totalFloors);
+	 *     console.log('Name of first floor: ' + floors.floorNames[0]);
+	 *   })
+	 *   .catch(function(error) {
+	 *     // Floors data retrieval error.
+	 *   });
+	 * ```
+	 * @deprecated Use the observable [[data]] collection instead
+	 */
+	getData(): Promise<Floor.Floors>;
+	/**
+	 * An observable collection of Floor data that can be subscribed to.
+	 *
+	 * See [[IObservableMap]] to learn how to receive data from the collection.
+	 *
+	 * ```
+	 * mpSdk.Floor.data.subscribe({
+	 *   onCollectionUpdated: function (collection) {
+	 *     console.log('Collection received. There are ', Object.keys(collection).length, 'floors in the collection');
+	 *   }
+	 * });
+	 * ```
+	 */
+	data: IObservableMap<Floor.FloorData>;
+	/**
+	 * An observable for the player's currently active floor.
+	 *
+	 * The current floor can tell you when "all floors" are visible and encodes when the camera is transitioning between floors.
+	 *
+	 * The following table shows all 4 states of the current floor observable
+	 * (INSIDE: inside mode, DH: dollhouse mode, FP: floorplan mode).
+	 *
+	 * |          | at sweep (INSIDE) or floor (DH, FP) | all floors (DH, FP) | transitioning | in unplaced 360º view |
+	 * |----------|-------------------------------------|---------------------|---------------|------------------------|
+	 * | id       | `${current.id}`                     | ''                  | ''            | undefined              |
+	 * | sequence | `${current.sequence}`               | -1                  | undefined     | undefined              |
+	 * | name     | `${current.name}`                   | 'all'               | ''            | ''                     |
+	 *
+	 * ```
+	 * mpSdk.Floor.current.subscribe(function (currentFloor) {
+	 *   // Change to the current floor has occurred.
+	 *   if (currentFloor.sequence === -1) {
+	 *     console.log('Currently viewing all floors');
+	 *   } else if (currentFloor.sequence === undefined) {
+	 *     if (currentFloor.id === undefined) {
+	 *       console.log('Current viewing an unplaced unaligned sweep');
+	 *     } else {
+	 *       console.log('Currently transitioning between floors');
+	 *     }
+	 *   } else {
+	 *     console.log('Currently on floor', currentFloor.id);
+	 *     console.log('Current floor\'s sequence index', currentFloor.sequence);
+	 *     console.log('Current floor\'s name', currentFloor.name)
+	 *   }
+	 * });
+	 * ```
+	 */
+	current: IObservable<Floor.ObservableFloorData>;
+	/**
+	 * When in inside mode, this function changes the active floor, and moves the camera to the nearest position on that floor.
+	 * When in floorplan/dollhouse mode, this function changes the active floor, but does not modify the camera
+	 *
+	 * ```
+	 * mpSdk.Floor.moveTo(2)
+	 *   .then(function(floorIndex) {
+	 *     // Move to floor complete.
+	 *     console.log('Current floor: ' + floorIndex);
+	 *   })
+	 *   .catch(function(error) {
+	 *     // Error moving to floor.
+	 *   });
+	 * ```
+	 *
+	 * @param index: The destination floor index
+	 * @return The destination floor index.
+	 */
+	moveTo(index: number): Promise<number>;
+	/**
+	 * This function displays all floors.
+	 *
+	 * ```
+	 * mpSdk.Floor.showAll()
+	 *   .then(function(){
+	 *     // Show floors complete.
+	 *   })
+	 *   .catch(function(error) {
+	 *     // Error displaying all floors.
+	 *   });
+	 * ```
+	 */
+	showAll(): Promise<void>;
+}
+export declare namespace Graph {
+	/**
+	 * A descriptor for a graph vertex. Used when adding vertices to a graph.
+	 */
+	type VertexDescriptor<T> = {
+		/** The id that can be used to lookup this vertex in the graph */
+		id: string;
+		/** Any user data to be associated with this vertex */
+		data: T;
+	};
+	/**
+	 * A descriptor for a graph vertex when no extra data will be associated with each vertex. Used when adding vertices to a graph.
+	 */
+	type VertexIdDescriptor = {
+		/** The id that can be used to lookup this vertex in the graph */
+		id: string;
+	};
+	/**
+	 * A descriptor for a graph edge. Used when adding edges to a graph.
+	 */
+	type EdgeDescriptor<T> = {
+		/** The source vertex. */
+		src: Vertex<T>;
+		/** The destination vertex. */
+		dst: Vertex<T>;
+		/** The weight of the edge. */
+		weight?: number;
+	};
+	/**
+	 * A node in the graph.
+	 */
+	type Vertex<T> = {
+		/**
+		 * The vertex's id.
+		 */
+		readonly id: string;
+		/**
+		 * User data associated with the vertex.
+		 */
+		readonly data: T;
+		/**
+		 * An iterable of all edges that have this vertex as its destination endpoint.
+		 *
+		 * ```typescript
+		 * const vertex = graph.vertex('a');
+		 * for (const edgeIn of vertex.edgesIn) {
+		 *   console.log(`vertex "${edgeIn.dst.id}" has an edge coming in from a vertex "${edgeIn.src.id}"`);
+		 * }
+		 * ```
+		 */
+		readonly edgesIn: IterableIterator<Edge<T>>;
+		/**
+		 * An iterable of all edges that have this vertex as its source endpoint.
+		 *
+		 * ```typescript
+		 * const vertex = graph.vertex('a');
+		 * for (const edgeOut of vertex.edgesOut) {
+		 *   console.log(`vertex "${edgeOut.src.id}" has an edge going to a vertex "${edgeOut.dst.id}"`);
+		 * }
+		 * ```
+		 */
+		readonly edgesOut: IterableIterator<Edge<T>>;
+		/**
+		 * An iterable of all vertices that can be traversed to from this vertex.
+		 *
+		 * ```typescript
+		 * const vertex = graph.vertex('a');
+		 * for (const neighbor of vertex.neighbors) {
+		 *   console.log(`vertex "${vertex.id}" shares an edge with "${neighbor.id}");
+		 * }
+		 * ```
+		 */
+		readonly neighbors: IterableIterator<Vertex<T>>;
+	};
+	/**
+	 * A weighted, directed connection between two vertices.
+	 *
+	 * @template T The type of any user data associated with each vertex in the graph.
+	 */
+	type Edge<T> = {
+		/** The vertex at the source of this edge. */
+		readonly src: Vertex<T>;
+		/** The vertex at the destination of this edge. */
+		readonly dst: Vertex<T>;
+		/** The weight associated with this edge. */
+		readonly weight: number;
+	};
+	/**
+	 * A directed, weighted graph data structure.
+	 *
+	 * @template T The type of any user data associated with each vertex in the graph.
+	 */
+	interface IDirectedGraph<T> {
+		/**
+		 * Watch a collection and update the graph as the collection changes.
+		 *
+		 * **Note:** If you need a graph of enabled sweeps, use [[Sweep.createGraph]] instead of the code snippet below
+		 *
+		 * ```
+		 * // create a graph of enabled sweeps
+		 * const graph = mpSdk.createGraph();
+		 * const sub = graph.watch({
+		 *   collection: mpSdk.Sweep.collection,
+		 *   isNeighborOf(sweepSrc, sweepDst) {
+		 *     return sweepSrc.data.neighbors.includes(sweepDst.id);
+		 *   },
+		 *   neighborsOf(sweepVertex) {
+		 *     return sweepVertex.data.neighbors.values();
+		 *   },
+		 *   weightBetween(sweepSrc, sweepDst) {
+		 *     const dx = sweepDst.data.position.x - sweepSrc.data.position.x;
+		 *     const dy = sweepDst.data.position.y - sweepSrc.data.position.y;
+		 *     const dz = sweepDst.data.position.z - sweepSrc.data.position.z;
+		 *     return Math.sqrt(dx ** 2 + dy ** 2 + dz ** 2);
+		 *   },
+		 *   shouldAdd(sweep) {
+		 *     return sweep.enabled;
+		 *   },
+		 * });
+		 *
+		 * // some time later when the graph no longer needs updating
+		 * sub.cancel();
+		 * ```
+		 * @param collectionAdaptor
+		 * @returns ISubscription
+		 */
+		watch(collectionAdaptor: ICollectionAdaptor<T>): ISubscription;
+		/**
+		 * Add a vertex or set of vertices to the graph.
+		 *
+		 * ```typescript
+		 * // for vertices with undefined "data" (no data associated with each vertex)
+		 * const undefGraph = mpSdk.Graph.createDirectedGraph<undefined>();
+		 * graph.addVertex(
+		 *   { id: 'a' },
+		 *   { id: 'b' },
+		 * );
+		 *
+		 * // for vertices with any other data
+		 * const graph = mpSdk.Graph.createDirectedGraph<number>();
+		 * graph.addVertex(
+		 *   { id: 'a', data: 1 },
+		 *   { id: 'b', data: 2 },
+		 * );
+		 * ```
+		 * @param vertexData A variable number of [[VertexDescriptor]]s to use to create nodes in the graph.
+		 */
+		addVertex(...vertexData: T extends undefined | void ? VertexIdDescriptor[] : Array<VertexDescriptor<T>>): void;
+		/**
+		 * Test if a vertex associated with `id` is present in the graph.
+		 *
+		 * ```typescript
+		 * if (graph.hasVertex('a')) {
+		 *   console.log('a vertex with id "a" was found');
+		 * }
+		 * ```
+		 * @param id The vertex's id.
+		 * @returns If a vertex with `id` exists, returns `true`. Otherwise, `false`.
+		 */
+		hasVertex(id: string): boolean;
+		/**
+		 * Get the vertex associated with `id`.
+		 *
+		 * ```typescript
+		 * const a = graph.vertex('a');
+		 * if (a) {
+		 *   console.log(`Found a vertex with id "${a.id}"`);
+		 * }
+		 * ```
+		 * @param id The vertex's id.
+		 * @returns If a vertex with `id` exists, returns the `Vertex`. Otherwise, `undefined`.
+		 */
+		vertex(id: string): Vertex<T> | undefined;
+		/**
+		 * Remove a vertex or a set of vertices from the graph.
+		 *
+		 * ```typescript
+		 * graph.removeVertex(a, b);
+		 * ```
+		 * @param vertices A variable number of vertices to remove.
+		 */
+		removeVertex(...vertices: Array<Vertex<T>>): void;
+		/**
+		 * An iterable of all vertices in the graph.
+		 *
+		 * ```typescript
+		 * for (const vertex of graph.vertices) {
+		 *   console.log(`vertex: ${vertex.id}`);
+		 * }
+		 * ```
+		 */
+		readonly vertices: IterableIterator<Vertex<T>>;
+		/**
+		 * The number of vertices in the graph.
+		 *
+		 * ```typescript
+		 * console.log(`the graph has ${graph.vertexCount} vertices`);
+		 * ```
+		 */
+		readonly vertexCount: number;
+		/**
+		 * Set the weight of an edge or set of edges between pairs of vertices representing the connections from `src` to `dst`.
+		 *
+		 * If an error is thrown, the graph is left untouched, no edges are added.
+		 * ```typescript
+		 * graph.setEdge(
+		 *   { src: a, dst: b, weight: 5  },
+		 *   { src: b, dst: c, weight: 10 },
+		 * );
+		 *
+		 * // update edge ab
+		 * graph.setEdge(
+		 *   { src: a, dst: b, weight: 10 },
+		 * );
+		 * ```
+		 * @param src The source vertex.
+		 * @param dst The destination vertex.
+		 * @param weight The weight assciated with the path from `src` to `dst`. Defaults to 0.
+		 * @throws If `src` or `dst` is not in the graph.
+		 * @throws If `weight` is negative or not a number.
+		 */
+		setEdge(...edgeDescs: Array<EdgeDescriptor<T>>): void;
+		/**
+		 * Get the edge that connects one vertex to another.
+		 *
+		 * ```typescript
+		 * const edge = graph.edge(a, b);
+		 * if (edge) {
+		 *   console.log(`Found an edge from "${edge.src.id}" to "${edge.dst.id}" with weight ${edge.weight}`);
+		 * }
+		 * ```
+		 * @param src The source vertex.
+		 * @param dst The destination vertex.
+		 * @returns If an edge from `src` to `dst` exists, returns the `Edge`. Otherwise, `undefined`.
+		 */
+		edge(src: Vertex<T>, dst: Vertex<T>): Edge<T> | undefined;
+		/**
+		 * Test if an edge from one vertex to another is present in the graph.
+		 *
+		 * ```typescript
+		 * if (graph.hasEdge(a, b)) {
+		 *   console.log('an edge from "a" to "b" was found');
+		 * }
+		 * ```
+		 * @param src The source vertex.
+		 * @param dst The destination vertex.
+		 * @returns If an edge from `src` to `dst` exists, returns `true`. Otherwise, `false`.
+		 */
+		hasEdge(src: Vertex<T>, dst: Vertex<T>): boolean;
+		/**
+		 * Remove an edge or a set of edges from the graph.
+		 *
+		 * ```typescript
+		 * graph.removeEdge(e1, e2);
+		 * ```
+		 * @param edges A variable number of edges to remove.
+		 */
+		removeEdge(...edges: Array<Edge<T>>): void;
+		/**
+		 * An iterable of all edges in the graph.
+		 *
+		 * ```typescript
+		 * for (const edge of graph.edges) {
+		 *   console.log(`edge: ${edge.src.id} -> ${edge.dst.id}`);
+		 * }
+		 * ```
+		 */
+		readonly edges: IterableIterator<Edge<T>>;
+		/**
+		 * The number of edges in the graph.
+		 *
+		 * ```typescript
+		 * console.log(`the graph has ${graph.edgeCount} edges`);
+		 * ```
+		 */
+		readonly edgeCount: number;
+		/**
+		 * Remove all vertices and edges from the graph.
+		 * Also call an optional `onDispose` provided at construction.
+		 *
+		 * ```typescript
+		 * graph.dispose();
+		 * // graph.vertexCount === 0
+		 * // graph.edgeCount === 0
+		 * ```
+		 */
+		dispose(): void;
+		/**
+		 * Subscribe to vertex changes.
+		 *
+		 * After this graph's vertices have been updated using [[addVertex]] or [[removeVertex]],
+		 * the `observer` attached will have its `onChanged` function called when [[commit]] is called.
+		 *
+		 * ```typescript
+		 * graph.onVerticesChanged({
+		 *   onChanged() {
+		 *     console.log(`this graph's vertices have changed`);
+		 *   }
+		 * });
+		 * ```
+		 * @param observer
+		 */
+		onVerticesChanged(observer: IObserver<void>): ISubscription;
+		/**
+		 * Subscribe to edge changes.
+		 *
+		 * After this graph's edges have been updated using [[setEdge]] or [[removeEdge]],
+		 * the `observer` attached will have its `onChanged` function called when [[commit]] is called.
+		 *
+		 * ```typescript
+		 * graph.onEdgesChanged({
+		 *   onChanged() {
+		 *     console.log(`this graph's edges have changed`);
+		 *   }
+		 * });
+		 * ```
+		 * @param observer
+		 */
+		onEdgesChanged(observer: IObserver<void>): ISubscription;
+		/**
+		 * Trigger any attached observers if there were changes to this graph.
+		 * If there are no changes to the graph, this is a no-op and no callbacks will be triggered.
+		 *
+		 * ```typescript
+		 * graph.commit();
+		 * ```
+		 */
+		commit(): void;
+	}
+	/**
+	 * An adaptor for an observable collection to automatically generate and update a graph.
+	 * Used in [[IDirectedGraph.watch]].
+	 */
+	interface ICollectionAdaptor<T> {
+		/**
+		 * A observable collection from the sdk, e.g. `mpSdk.Sweep.data`.
+		 */
+		collection: IObservableMap<T>;
+		/**
+		 * Determines whether or not an item from the collection should be considered a neighbor of another item.
+		 * @param src A vertex containing the source item
+		 * @param dst A vertex containing the destination item
+		 */
+		isNeighborOf(src: Vertex<T>, dst: Vertex<T>): boolean;
+		/**
+		 * Get a list of ids for other vertices that should be considered neighbors to an item in the collection.
+		 * @param item
+		 */
+		neighborsOf(item: Vertex<T>): IterableIterator<string>;
+		/**
+		 * Get the weight between two items in the collection to use as the connecting edges weight.
+		 * @param src
+		 * @param dst
+		 */
+		weightBetween(src: Vertex<T>, dst: Vertex<T>): number;
+		/**
+		 * Determines whether or not an item from the collection will be added as a graph vertex.
+		 * @param item
+		 */
+		shouldAdd?(item: T): boolean;
+	}
+	/**
+	 * The status of an A* search.
+	 */
+	enum AStarStatus {
+		/** A path was found. */
+		SUCCESS = "astar.status.success",
+		/** No path was found. */
+		NO_PATH = "astar.status.no_path",
+		/** A path wasn't found in the time specified. */
+		TIMEOUT = "astar.status.timeout",
+		/** The start vertex was not found in the graph. */
+		NO_START_VERTEX = "astar.status.no_start",
+		/** The end vertex was not found in the graph. */
+		NO_END_VERTEX = "astar.status.no_end"
+	}
+	/**
+	 * The result of doing an A* search.
+	 */
+	type AStarResult<T> = {
+		/** Whether the search was successful, timed out, or if there was no path found. */
+		status: AStarStatus;
+		/** The total cost of tranversing the path. */
+		cost: number;
+		/** On success, contains the path of vertices. */
+		path: Array<Vertex<T>>;
+	};
+	/**
+	 * Options that can configure how the A* algorithm runs.
+	 */
+	interface SearchOptions<T> {
+		/** An estimate of the "distance" between `vertexA` and `vertexB`. The default heuristic function returns 0. */
+		heuristic(vertexA: Vertex<T>, vertexB: Vertex<T>, edge: Edge<T>): number;
+	}
+	/**
+	 * An object that encapsulates a graph and can be used to execute A* or subscribe to A* for potential changes.
+	 */
+	interface IAStarRunner<T> {
+		/**
+		 * Do the A* search.
+		 * @param timeout The amount of time to spend trying to find a path. Defaults to 5000ms.
+		 * @returns {AStarResult<T>} The results of running A*.
+		 *
+		 * ```typescript
+		 * const aStarRunner = mpSdk.Graph.createAStarRunner(...);
+		 * const result = aStarRunner.exec();
+		 * if (result.status === mpSdk.Graph.AStarStatus.SUCCESS) {
+		 *   console.log('found a path of length', result.path.length);
+		 * }
+		 * ```
+		 */
+		exec(timeout?: number): AStarResult<T>;
+		/**
+		 * Subscribe to changes in the underlying graph and receive a callback in `observer` when changes are detected.
+		 * @param observer
+		 * @returns {ISubscription} A subscription to stop listening for changes to the graph.
+		 *
+		 * ```typescript
+		 * const aStarRunner = mpSdk.Graph.createAStarRunner(...);
+		 * const subscription = aStarRunner.subscribe({
+		 *   onChanged(runner) {
+		 *     const result = runner.exec();
+		 *     if (result.status === mpSdk.Graph.AStarStatus.SUCCESS) {
+		 *       console.log('found a path of length', result.path.length);
+		 *     }
+		 *   }
+		 * });
+		 * // ... some time later when the runner is no longer needed
+		 * subscription.cancel();
+		 * ```
+		 */
+		subscribe(observer: IObserver<Graph.IAStarRunner<T>> | ObserverCallback<Graph.IAStarRunner<T>>): ISubscription;
+		/**
+		 * Release resources associated with the runner.
+		 * This function should be called once you are done with the runner.
+		 */
+		dispose(): void;
+	}
+}
+export interface Graph {
+	AStarStatus: typeof Graph.AStarStatus;
+	/**
+	 * Create an empty graph data structure.
+	 *
+	 * ```
+	 * const graph = mpSdk.Graph.createDirectedGraph();
+	 * ```
+	 * @param onDispose An optional callback to be called when [[IDirectedGraph.dispose]] is called
+	 * @template T The type of any user data associated with each vertex in the graph.
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.55.2-34-ga9934ccd93
+	 */
+	createDirectedGraph<T>(onDispose?: () => void): Graph.IDirectedGraph<T>;
+	/**
+	 * Create a "runner" for the A* algorithm around a `graph`, and `start` and `end` vertices.
+	 *
+	 * The runner encapsulates the details of the graph and search, caches the results of A*,
+	 * and provides a way to subscribe to potential changes in the path signifying that the results of [[Graph.AStarRunner.exec]] may have changed.
+	 *
+	 * ```typescript
+	 * const graph = mpSdk.Graph.createDirectedGraph();
+	 * // ... setup graph vertices and edges
+	 * const start = graph.vertex('start');
+	 * const end = graph.vertex('end');
+	 * const aStarRunner = mpSdk.Graph.createAStarRunner(graph, start, end);
+	 * const result = aStarRunner.exec();
+	 * ```
+	 *
+	 * @param graph The graph to traverse
+	 * @param start The start vertex.
+	 * @param end The end vertex.
+	 * @param options An optional `heuristic` function.
+	 * @return {graph.AStarRunner} A runner for A* that can execute the search or be subscribed to.
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.55.2-34-ga9934ccd93
+	 */
+	createAStarRunner<T>(graph: Graph.IDirectedGraph<T>, start: Graph.Vertex<T>, end: Graph.Vertex<T>, options?: Partial<Graph.SearchOptions<T>>): Graph.IAStarRunner<T>;
+}
+export declare namespace Label {
+	type Label = {
+		position: Vector3;
+		sid: string;
+		text: string;
+		visible: boolean;
+		/** @deprecated Use [[floorInfo]] instead */
+		floor: number;
+		floorInfo: {
+			id: string;
+			sequence: number;
+		};
+	};
+	type LabelDeprecated = {
+		position: Vector3;
+		sid: string;
+		text: string;
+		visible: boolean;
+		/** @deprecated Use [[floorInfo]] instead */
+		floor: number;
+		floorInfo: {
+			id: string;
+			sequence: number;
+		};
+		screenPosition: Vector2;
+	};
+	enum Event {
+		/** @event */
+		POSITION_UPDATED = "label.positionupdated"
+	}
+}
+export interface Label {
+	Event: typeof Label.Event;
+	/**
+	 * This function returns the data of all labels.
+	 *
+	 * @deprecated Use [[data]] observable instead.
+	 */
+	getData(): Promise<Label.LabelDeprecated[]>;
+	/**
+	 * An observable map of the current labels.
+	 * Returns an object with a map of labels.
+	 *
+	 * ```
+	 * mpSdk.Label.data.subscribe({
+	 *  onAdded: function (index, item, collection) {
+	 *    console.log('Label added to the collection', index, item, collection);
+	 *  },
+	 *  onRemoved: function (index, item, collection) {
+	 *    console.log('Label removed from the collection', index, item, collection);
+	 *  },
+	 *  onUpdated: function (index, item, collection) {
+	 *    console.log('Label updated in place in the collection', index, item, collection);
+	 *  },
+	 * });
+	 * ```
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.68.12-7-g858688944a
+	 */
+	data: IObservableMap<Label.Label>;
+}
+export declare namespace Link {
+	/**
+	 * The behavior to use when creating a link.
+	 */
+	enum CreationPolicy {
+		/** Use Showcase's current window.location as the base of the link */
+		WINDOW = "link.creationpolicy.window",
+		/** Use the embedder's window.location as the base of the link */
+		REFERRER = "link.creationpolicy.referrer",
+		/** Use the original Matterport link as the base of the link */
+		MATTERPORT = "link.creationpolicy.matterport"
+	}
+	/**
+	 * The behavior to use when clicking a link
+	 */
+	enum OpenPolicy {
+		/** Use the default behavior for the associated link type */
+		DEFAULT = "link.openpolicy.default",
+		/** Open a new tab or window */
+		NEW_WINDOW = "link.openpolicy.newwindow",
+		/** Open in the current iframe */
+		SAME_FRAME = "link.openpolicy.sameframe",
+		/** Navigate the window that is the current embedder of Showcase */
+		CURRENT_WINDOW = "link.openpolicy.current"
+	}
+	enum DestinationPolicy {
+		/** Navigate to the default destination for links; likely the Showcase embedder's domain */
+		DEFAULT = "link.destination.default",
+		/** Navigate directly to the Showcase of a Matterport space */
+		MATTERPORT = "link.destination.matterport"
+	}
+	type CreateLinkOptions = {
+		/** The list of URL parameters to include in the share link */
+		includeParams: string[];
+	};
+	type OpenPolicyOptions = {
+		/**
+		 * An optional template for the link to use when the policy is not set to `SAME_FRAME`,
+		 * that will have any `${[param]}` substrings interpolated using the current set of URL parameters.
+		 *
+		 * If `${[param]}` is included in the path of the URL, it will be replaced by the current URL parameter's value or undefined (`${m}/show`: `abc123/show`).
+		 *
+		 * If `${[param]}` is included in the search parameters of the URL, it and it's value wil be appended ot the URL (`${m}`: `m=abc123`).
+		 *
+		 * URL parameters that are unset will be appended without a value. (`${unset}`: `unset`)
+		 *
+		 * Note: `${m}` or `${model} are special cases in model links.
+		 * Instead of the current window's "model" param, the model ID from the link will be used instead.
+		 *
+		 * As an example, the string `"https://my.domain.com/${m}/show.html?${play}&${unset}"` interpolated at the URL `https://my.domain.com/show/?m=abc123&play=1`
+		 * will result in a URL like `"https://my.domain.com/abc123/show.html?play=1&unset&m=abc123"`.
+		 */
+		templateHref: string;
+	};
+}
+export interface Link {
+	CreationPolicy: typeof Link.CreationPolicy;
+	OpenPolicy: typeof Link.OpenPolicy;
+	/**
+	 * Create a shareable link to the current Showcase player.
+	 * ```typescript
+	 * const link = await sdk.Link.createLink();
+	 * ```
+	 *
+	 * @embed
+	 * @bundle 3.1.60.12-32-g4572017c98
+	 */
+	createLink(): Promise<string>;
+	/**
+	 * Create a deep link to the current location of the current Showcase player.
+	 * ```typescript
+	 * const deepLink = await sdk.Link.createDeepLink();
+	 * ```
+	 *
+	 * @embed
+	 * @bundle 3.1.60.12-32-g4572017c98
+	 */
+	createDeepLink(): Promise<string>;
+	/**
+	 * Change how the link the share dialog and the [[createLink]] and [[createDeepLink]] links are created.
+	 *
+	 * ```typescript
+	 * await sdk.Link.setShareLinkPolicy(sdk.Link.CreationPolicy.REFERRER);
+	 * const link = await sdk.Link.createLink();
+	 * console.log(link); // should log a link to your page that embeds Showcase
+	 * ```
+	 * @param policy
+	 * @param options
+	 *
+	 * @embed
+	 * @bundle 3.1.60.12-32-g4572017c98
+	 */
+	setShareLinkPolicy(policy: Link.CreationPolicy, options?: Partial<Link.CreateLinkOptions>): Promise<void>;
+	/**
+	 * Change the behavior of clicking a link to another model.
+	 *
+	 * ```typescript
+	 * sdk.Link.setModelLinkPolicy(sdk.Link.OpenPolicy.NEW_WINDOW);
+	 * // clicking a link to another model will now open a new window
+	 * ```
+	 *
+	 * @param policy
+	 * @param options
+	 *
+	 * @embed
+	 * @bundle 3.1.60.12-32-g4572017c98
+	 */
+	setModelLinkPolicy(policy: Link.OpenPolicy, options?: Partial<Link.OpenPolicyOptions>): Promise<void>;
+	setModelLinkPolicy(policy: Link.OpenPolicy, destination: Link.DestinationPolicy): Promise<void>;
+	/**
+	 * Change the behavior of clicking a link to a location within the current model.
+	 *
+	 * ```typescript
+	 * // when clicking a link with a location within the current model, open a new window with the model at the location
+	 * // instead of navigating the current model to the new location
+	 * sdk.Link.setNavigationLinkPolicy(sdk.Link.OpenPolicy.NEW_WINDOW, {
+	 *   templateHref: 'https://example.com/${m}/show.html?',
+	 * });
+	 *
+	 * // revert the navigation link behavior to the default
+	 * sdk.Link.setNavigationLinkPolicy(sdk.Link.OpenPolicy.DEFAULT);
+	 * ```
+	 *
+	 * @param policy
+	 * @param options`
+	 *
+	 * @embed
+	 * @bundle 3.1.60.12-32-g4572017c98
+	 */
+	setNavigationLinkPolicy(policy: Link.OpenPolicy, options?: Partial<Link.OpenPolicyOptions>): Promise<void>;
+	/**
+	 * Change the behavior of clicking a link to a page from the same origin as the one hosting Showcase.
+	 *
+	 * ```typescript
+	 * sdk.Link.setSameOriginLinkPolicy(sdk.Link.OpenPolicy.CURRENT_WINDOW);
+	 * // clicking a link with the same origin as Showcase's embedder will now navigate the embedding page
+	 *
+	 * sdk.Link.setSameOriginLinkPolicy(sdk.Link.OpenPolicy.SAME_FRAME);
+	 * // clicking a link with the same origin as Showcase's embedder will now navigate Showcase's iframe to that page
+	 * ```
+	 *
+	 * @param policy
+	 *
+	 * @embed
+	 * @bundle 3.1.60.12-32-g4572017c98
+	 */
+	setSameOriginLinkPolicy(policy: Link.OpenPolicy): Promise<void>;
+	/**
+	 * Change the behavior of clicking a link to a different origin.
+	 *
+	 * ```typescript
+	 * sdk.Link.setExternalLinkPolicy(false);
+	 * // clicking an external link will now navigate the current page (not the Showcase iframe) to the link
+	 *
+	 * ```
+	 *
+	 * @param openInNewWindow Open the link in a new tab or window; otherwise, replace the embedder's window.
+	 * true is the default behavior.
+	 *
+	 * @embed
+	 * @bundle 3.1.60.12-32-g4572017c98
+	 */
+	setExternalLinkPolicy(openInNewWindow: boolean): Promise<void>;
+}
+export declare namespace Mattertag {
+	type MattertagData = {
+		sid: string;
+		enabled: boolean;
+		/** The world space position of the mattertag anchor within the model */
+		anchorPosition: Vector3;
+		/** The world space (non-normal) direction of the mattertag's stem */
+		stemVector: Vector3;
+		stemVisible: boolean;
+		label: string;
+		description: string;
+		/** @deprecated */
+		parsedDescription: DescriptionChunk[];
+		media: {
+			type: MediaType;
+			src: string;
+		};
+		color: Color;
+		/** @deprecated Use [[floorInfo]] instead */
+		floorId: number;
+		/** @deprecated Use [[floorInfo]] instead */
+		floorIndex: number;
+		floorInfo: {
+			id: string;
+			sequence: number;
+		};
+		/** @deprecated Use [[media.type]] instead */
+		mediaType: MediaType;
+		/** @deprecated Use [[media.src]] instead */
+		mediaSrc: string;
+		/** @deprecated Use [[stemVector]] instead */
+		anchorNormal: Vector3;
+		/** @deprecated Calculate the length of [[stemVector]] instead */
+		stemHeight: number;
+	};
+	type ObservableMattertagData = {
+		sid: string;
+		enabled: boolean;
+		/** The world space position of the mattertag anchor within the model */
+		anchorPosition: Vector3;
+		/** The world space (non-normal) direction of the mattertag's stem */
+		stemVector: Vector3;
+		stemVisible: boolean;
+		label: string;
+		description: string;
+		media: {
+			type: MediaType;
+			src: string;
+		};
+		color: Color;
+		/** @deprecated Use [[floorInfo]] instead */
+		floorIndex: number;
+		floorInfo: {
+			id: string;
+			sequence: number;
+		};
+	};
+	enum Transition {
+		INSTANT = "transition.instant",
+		FLY = "transition.fly",
+		FADEOUT = "transition.fade"
+	}
+	interface DescriptionChunk {
+		text?: string;
+		link?: Link;
+		type: DescriptionChunkType;
+	}
+	interface Link {
+		label: string;
+		url: string;
+		type: LinkType;
+		navigationData?: any;
+	}
+	/**
+	 * Options that can be specified when injection custom HTML into a Mattertag.
+	 */
+	type InjectionOptions = {
+		/** The size of the frame to create */
+		size?: Size;
+		/**
+		 * @deprecated This option is no longer required and will be ignored
+		 */
+		windowPath?: string;
+		/**
+		 * A map for the global functions and variables we provide in your iframe sandbox.
+		 * Only needs to be used if scripts you are importing also have a global `send`, `on`, `off`, or `tag`.
+		 */
+		globalVariableMap?: GlobalVariableMap;
+	};
+	/**
+	 * Map the globals we provide in your sandbox to other names.
+	 */
+	type GlobalVariableMap = {
+		send?: string;
+		on?: string;
+		off?: string;
+		tag?: string;
+	};
+	/**
+	 * A messaging object to send and receive messages to and from your iframe sandbox.
+	 */
+	interface IMessenger {
+		/**
+		 * Send a messages of type `eventType` to the iframe sandbox with any optional data associated with the message
+		 */
+		send(eventType: string, ...args: any[]): void;
+		/**
+		 * Add a handler for messages of type `eventType` from the iframe sandbox
+		 */
+		on(eventType: string, eventHandler: (...args: any[]) => void): void;
+		/**
+		 * Remove a handler for messages of type `eventType` from the iframe sandbox
+		 */
+		off(eventType: string, eventHandler: (...args: any[]) => void): void;
+	}
+	type PreventableActions = {
+		opening: boolean;
+		navigating: boolean;
+	};
+	enum LinkType {
+		/** A link to another position in the current model */
+		NAVIGATION = "tag.link.nav",
+		/** A link to a different Matterport model */
+		MODEL = "tag.link.model",
+		/** An external link */
+		EXT_LINK = "tag.link.ext"
+	}
+	enum DescriptionChunkType {
+		NONE = "tag.chunk.none",
+		TEXT = "tag.chunk.text",
+		LINK = "tag.chunk.link"
+	}
+	enum Event {
+		/** @event */
+		HOVER = "tag.hover",
+		/** @event */
+		CLICK = "tag.click",
+		/** @event */
+		LINK_OPEN = "tag.linkopen"
+	}
+	enum MediaType {
+		NONE = "mattertag.media.none",
+		PHOTO = "mattertag.media.photo",
+		VIDEO = "mattertag.media.video",
+		RICH = "mattertag.media.rich"
+	}
+	/**
+	 * A subset of the MattertagData used to add Mattertags through the sdk.
+	 * Most properties are optional except those used for positioning: `anchorPosition`, `stemVector`.
+	 */
+	interface MattertagDescriptor {
+		anchorPosition: Vector3;
+		stemVector: Vector3;
+		stemVisible?: boolean;
+		label?: string;
+		description?: string;
+		media?: {
+			type: MediaType;
+			src: string;
+		};
+		color?: Color;
+		/** @deprecated Use [[floorIndex]] instead */
+		floorId?: number;
+		floorIndex?: number;
+		iconId?: string;
+	}
+	type EditableProperties = {
+		label: string;
+		description: string;
+		media: {
+			type: MediaType;
+			src: string;
+		};
+	};
+	interface PositionOptions {
+		anchorPosition: Vector3;
+		stemVector: Vector3;
+		/** @deprecated Use [[floorIndex]] instead */
+		floorId: number;
+		floorIndex: number;
+	}
+}
+export interface Mattertag {
+	Transition: typeof Mattertag.Transition;
+	LinkType: typeof Mattertag.LinkType;
+	DescriptionChunkType: typeof Mattertag.DescriptionChunkType;
+	Event: typeof Mattertag.Event;
+	MediaType: typeof Mattertag.MediaType;
+	/**
+	 * This function returns metadata on the collection of Mattertags.
+	 *
+	 * @deprecated Use [[Tag.data]] instead
+	 */
+	getData(): Promise<Mattertag.MattertagData[]>;
+	/**
+	 * An observable collection of Mattertag data that can be subscribed to.
+	 *
+	 * @deprecated Use [[Tag.data]] instead
+	 */
+	data: IObservableMap<Mattertag.ObservableMattertagData>;
+	/**
+	 * This function navigates to the Mattertag disc with the provided sid, opening the billboard on arrival.
+	 *
+	 * ```
+	 * mpSdk.Mattertag.navigateToTag(sid, mpSdk.Mattertag.Transition.FLY);
+	 * ```
+	 *
+	 * @param tagSid The sid of the Mattertag to navigate to
+	 * @param transition The type of transition to navigate to a sweep where the Mattertag disc is visible
+	 * @param force If navigating to the tag is disabled, passing force === true will force the transition to occur
+	 */
+	navigateToTag(tagSid: string, transition: Mattertag.Transition, force?: boolean): Promise<string>;
+	/**
+	  * Get the disc's (3d) position of a Mattertag.
+	  *
+	  * @deprecated Disc position is automatially included in [[Tag.data]]
+	  */
+	getDiscPosition(tag: Mattertag.MattertagData | Mattertag.ObservableMattertagData, result?: Vector3): Vector3;
+	/**
+	 * Add one or more Mattertags to Showcase.
+	 * Each input Mattertag supports setting the label, description, color, anchorPosition, and stemVector.
+	 *
+	 * Two properties are required:
+	 * - `anchorPosition`, the point where the tag connects to the model
+	 * - `stemVector`, the direction, aka normal, and height that the Mattertag stem points
+	 *
+	 * See [[Pointer.intersection]] for a way to retrive a new `anchorPosition` and `stemVector`.
+	 *
+	 * **Note**: these changes are not persisted between refreshes of Showcase. They are only valid for the current browser session.
+	 *
+	 * @param newTagData A single or array of Mattertag templates to add.
+	 * @return A promise that resolves with the sids for the newly added Mattertags.
+	 *
+	 * @deprecated Use [[Tag.add]] instead
+	 */
+	add(newTagData: Mattertag.MattertagDescriptor | Mattertag.MattertagDescriptor[]): Promise<string[]>;
+	/**
+	 * Edit the data in a Mattertag billboard.
+	 *
+	 * **Note**: these changes are not persisted between refreshes of Showcase. They are only valid for the current browser session.
+	 *
+	 * @param tagSid the sid of the Mattertag to edit
+	 * @param properties A dictionary of properties to set
+	 *
+	 * @deprecated Use [[Tag.editBillboard]] or [[Tag.registerAttachment]] and/or [[Tag.attach]] to manage media
+	 */
+	editBillboard(tagSid: string, properties: Partial<Mattertag.EditableProperties>): Promise<void>;
+	/**
+	 * Move and reorient a Mattertag.
+	 *
+	 * See [[Pointer.intersection]] for a way to retrieve a new `anchorPosition` and `stemVector`.
+	 *
+	 * **Note**: these changes are not persisted between refreshes of Showcase. They are only valid for the current browser session.
+	 *
+	 * @param tagSid The sid of the Mattertag to reposition
+	 * @param moveOptions The new anchorPosition, stemVector and/or floorId.
+	 *
+	 * @deprecated Use [[Tag.editPosition]] instead
+	 */
+	editPosition(tagSid: string, moveOptions: Partial<Mattertag.PositionOptions>): Promise<void>;
+	/**
+	 * Edit the color of a Mattertag
+	 *
+	 * @param tagSid The sid of the Mattertag to edit
+	 * @param color The new color to be applied to the Mattertag disc
+	 *
+	 * @deprecated Use [[Tag.editColor]] instead
+	 */
+	editColor(tagSid: string, color: Color): Promise<void>;
+	/**
+	 * Edit the opacity of a Mattertag
+	 *
+	 * @param tagSid The sid of the Mattertag to edit
+	 * @param opacity The target opacity for the Mattertag in the range of [0, 1]
+	 *
+	 * @deprecated Use [[Tag.editOpacity]] instead
+	 */
+	editOpacity(tagSid: string, opacity: number): Promise<void>;
+	/**
+	 * Edit the stem of a Mattertag
+	 *
+	 * @param tagSid The sid of the Mattertag to edit
+	 * @param stemOptions What to change about the Mattertag's stem - can include stemHeight and stemVisible
+	 * @introduced 3.1.70.10-0-ge9cb83b28c
+	 *
+	 * @deprecated Use [[Tag.editStem]] instead
+	 */
+	editStem(tagSid: string, options: {
+		stemHeight?: number;
+		stemVisible?: boolean;
+	}): Promise<void>;
+	/**
+	 * Register an icon to use with subsequent [[Mattertag.editIcon]] calls.
+	 *
+	 * **Note**: It is recommended to host your own images to mitigate cross origin limitations.
+	 *
+	 * @param iconId A user specified string to use as a lookup of this icon
+	 * @param iconSrc The src of the icon, like the src of an \<img>
+	 *
+	 * @deprecated Use [[Asset.registerTexture]] instead
+	 */
+	registerIcon(iconId: string, iconSrc: string): Promise<void>;
+	/**
+	 * Change the icon of the Mattertag disc
+	 *
+	 * **Note**: these changes are not persisted between refreshes of Showcase. They are only valid for the current browser session.
+	 *
+	 *
+	 * @param tagSid The sid of the Mattertag to edit
+	 * @param iconId The id of the icon to apply
+	 *
+	 * **Errors**
+	 *
+	 * Warns if the provided `iconSrc` is an .svg file which doesn't have a `'width'` or `'height'` attribute.
+	 * Defaults to a resolution of 128x128 if neither exist.
+	 *
+	 * @deprecated Use [[Tag.editIcon]] instead
+	 */
+	editIcon(tagSid: string, iconId: string): Promise<void>;
+	/**
+	 * Resets the icon of the Mattertag disc back to its original icon.
+	 *
+	 * @param tagSid The sid of the Mattertag to reset
+	 *
+	 * @deprecated Use [[Tag.resetIcon]] instead
+	 */
+	resetIcon(tagSid: string): Promise<void>;
+	/**
+	 * Removes one or more Mattertags from Showcase.
+	 *
+	 * **Note**: these changes are not persisted between refreshes of Showcase. They are only valid for the current browser session.
+	 *
+	 * @param tagSids A single Mattertag sid or array of Mattertag sids to remove.
+	 * @return A promise with an array of Mattertag sids that were actually removed.
+	 *
+	 * @deprecated Use [[Tag.remove]] instead
+	 */
+	remove(tagSids: string | string[]): Promise<string[]>;
+	/**
+	 * Prevents the "default" Showcase action on a Mattertag from occurring: hover to open billboard, click to navigate to view.
+	 *
+	 * @param tagSid The sid of the Mattertag to remove actions from
+	 * @param actions The set of actions to prevent
+	 *
+	 * @deprecated Use [[Tag.allowAction]] instead
+	 */
+	preventAction(tagSid: string, actions: Partial<Mattertag.PreventableActions>): Promise<void>;
+	/**
+	 * Add a custom frame that can host custom HTML and JavaScript, and communicate bi-directionally with your page.
+	 *
+	 * The frame that contains your custom code will have certain limitations due to being sandboxed by the `sandbox='allow-scripts` attribute.
+	 * Attempting to access properties of other windows will also be blocked by the browser.
+	 * ([see the MDN pages about iframe sandbox](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe))
+	 *
+	 * Currently, the HTML CAN ONLY BE SET ONCE by a call to `injectHTML`. This includes removing or clearing the HTML.
+	 *
+	 * @deprecated Use [[Tag.registerSandbox]] and [[Tag.attach]] instead
+	 */
+	injectHTML(tagSid: string, html: string, options: Mattertag.InjectionOptions): Promise<Mattertag.IMessenger>;
+}
+export declare namespace Measurements {
+	type MeasurementData = {
+		sid: string;
+		label: string;
+		floor: number;
+		start: Vector3;
+		end: Vector3;
+	};
+	/**
+	 * The data associated with Showcase's measurement mode
+	 */
+	type MeasurementModeData = {
+		/** A unique identifier for this measurement */
+		sid: string;
+		/** The list of wold-space coordinates that compose this measurement */
+		points: Vector3[];
+		/** The total length of the measurement */
+		totalLength: number;
+		/** The length of each segment between consecutive pairs of points */
+		segmentLengths: number[];
+		/** The user-set "description" of this measurement */
+		label: string;
+	};
+	type State = {
+		active: boolean;
+	};
+}
+export interface Measurements {
+	/**
+	 * This function returns metadata on the collection of Measurements.
+	 *
+	 * ```
+	 * mpSdk.Measurement.getData()
+	 *   .then(function(Measurements) {
+	 *     // Measurement data retreival complete.
+	 *     if(Measurements.length > 0) {
+	 *       console.log('First Measurement label: ' + Measurements[0].label);
+	 *       console.log('First Measurement description: ' + Measurements[0].description);
+	 *     }
+	 *   })
+	 *   .catch(function(error) {
+	 *     // Measurement data retrieval error.
+	 *   });
+	 * ```
+	 */
+	getData(): Promise<Measurements.MeasurementData[]>;
+	/**
+	 * An observable collection of measurement mode data that can be subscribed to.
+	 *
+	 * ```
+	 * mpSdk.Measurements.data.subscribe({
+	 *   onAdded: function (index, item, collection) {
+	 *     console.log('item added to the collection', index, item, collection);
+	 *   },
+	 *   onRemoved: function (index, item, collection) {
+	 *     console.log('item removed from the collection', index, item, collection);
+	 *   },
+	 *   onUpdated: function (index, item, collection) {
+	 *     console.log('item updated in place in the collection', index, item, collection);
+	 *   },
+	 *   onCollectionUpdated: function (collection) {
+	 *     console.log('the entire up-to-date collection', collection);
+	 *   }
+	 * });
+	 * ```
+	 */
+	data: IObservableMap<Measurements.MeasurementModeData>;
+	/**
+	 * Activate or deactivate measurement mode. This function can only be used after the application has started playing.
+	 * Use [[App.state]] to determine the phase of the application.
+	 *
+	 * ```
+	 * mpSdk.Measurements.toggleMode(true)
+	 *   .then(() => {
+	 *     console.log('measurement mode is now active');
+	 *   });
+	 * ```
+	 */
+	toggleMode(activate: boolean): Promise<void>;
+	/**
+	   * An observable measurement mode state object.
+	   *
+	   * ```
+	   * mpSdk.Measurements.mode.subscribe(function (measurementModeState) {
+	   *  // measurement mode state has changed
+	   *  console.log('Is measurement mode currently active? ', measurementModeState.active);
+	   * });
+	   *
+	   * // output
+	   * // > Is measurement mode currently active? true
+	   * ```
+	   */
+	mode: IObservable<Measurements.State>;
+}
+export declare namespace Sweep {
+	type SweepData = {
+		/** @deprecated Use [[sid]] instead */
+		uuid: string;
+		sid: string;
+		alignmentType: Alignment;
+		placementType: Placement;
+		neighbors: string[];
+		position: Vector3;
+		rotation: Vector3;
+		floor: number;
+	};
+	type ObservableSweepData = {
+		/** @deprecated Use [[id]] instead */
+		uuid: string;
+		/** @deprecated Use [[id]] instead */
+		sid: string;
+		id: string;
+		enabled: boolean;
+		alignmentType: Alignment;
+		placementType: Placement;
+		neighbors: string[];
+		position: Vector3;
+		rotation: Vector3;
+		floorInfo: SweepFloorInfo | EmptySweepFloorInfo;
+	};
+	type SweepFloorInfo = {
+		id: string;
+		sequence: number;
+	};
+	type EmptySweepFloorInfo = {
+		id: undefined;
+		sequence: undefined;
+	};
+	/**
+	 * `rotation.x`: is the amount the camera will rotate up/down, in the range between [-90…90]
+	 * with -90 being straight down and 90 being straight up, 45 would be looking up at a 45 degree angle., -45 down etc..
+	 * `rotation.y`: is the amount the camera rotate around horizontally, between [-360…0…360],
+	 * negative values to rotate to the left, positive to rotate to the right.
+	 *
+	 * Note: The rotation that Sweep.moveTo uses for input is the same rotation that will get returned from the [[Camera.pose]] property.
+	 *
+	 * ```
+	 * const cachedPose = null;
+	 * mpSdk.Camera.pose.subscribe(function (pose) {
+	 *   cachedPose = pose;
+	 * })
+	 *
+	 * // If the pose is returned immediately.
+	 * console.log(cachedPose.rotation);
+	 * ```
+	 */
+	type MoveToOptions = {
+		rotation?: Rotation;
+		transition?: Transition;
+		/**
+		 * Total transition time in milliseconds.
+		 */
+		transitionTime?: number;
+	};
+	enum Event {
+		/**
+		 * @event
+		 */
+		ENTER = "sweep.enter",
+		EXIT = "sweep.exit"
+	}
+	enum Transition {
+		INSTANT = "transition.instant",
+		FLY = "transition.fly",
+		FADEOUT = "transition.fade"
+	}
+	enum Alignment {
+		ALIGNED = "aligned",
+		UNALIGNED = "unaligned"
+	}
+	enum Placement {
+		UNPLACED = "unplaced",
+		AUTO = "auto",
+		MANUAL = "manual"
+	}
+	namespace Conversion {
+		/**
+		 * Generate a map between v2 IDs and v1 IDs
+		 *
+		 * This method will help with migration between IDs used for sweeps.
+		 *
+		 * ```
+		 * const mapping = await mpSdk.Sweep.Conversion.createIdMap();
+		 * ```
+		 *
+		 * @param invert?: boolean - if passed, return map of v1->v2 instead
+		 */
+		function createIdMap(invert?: boolean): Promise<Dictionary<string>>;
+		/**
+		 * Return the label associated with the provided sweep ID
+		 *
+		 * The label is what's displayed for the sweep in the workshop
+		 *
+		 * ```
+		 * const label = mpSdk.Sweep.Conversion.getLabelFromId('abcdefghijklmno0123456789');
+		 * ```
+		 *
+		 * @param id
+		 */
+		function getLabelFromId(id: string): Promise<string>;
+	}
+}
+export interface Sweep {
+	Event: typeof Sweep.Event;
+	Transition: typeof Sweep.Transition;
+	Alignment: typeof Sweep.Alignment;
+	Placement: typeof Sweep.Placement;
+	Conversion: typeof Sweep.Conversion;
+	/**
+	 * An observable collection of sweep data that can be subscribed to.
+	 *
+	 * ```
+	 * mpSdk.Sweep.data.subscribe({
+	 *   onAdded: function (index, item, collection) {
+	 *     console.log('sweep added to the collection', index, item, collection);
+	 *   },
+	 *   onRemoved: function (index, item, collection) {
+	 *     console.log('sweep removed from the collection', index, item, collection);
+	 *   },
+	 *   onUpdated: function (index, item, collection) {
+	 *     console.log('sweep updated in place in the collection', index, item, collection);
+	 *   },
+	 *   onCollectionUpdated: function (collection) {
+	 *     console.log('the entire up-to-date collection', collection);
+	 *   }
+	 * });
+	 * ```
+	 */
+	data: IObservableMap<Sweep.ObservableSweepData>;
+	/**
+	 * A graph of enabled sweeps that can be used for pathfinding.
+	 * This graph will automatically update as sweeps change and trigger any observers.
+	 * The weight of each edge is the Euclidean distance from a sweep to its neighbor.
+	 *
+	 * Enabling a sweep will automatically add it and its edges to the graph.<br>
+	 * Disabling a sweep will automatically remove it and its edges from the graph.
+	 *
+	 * ```typescript
+	 * const sweepGraph = await mpSdk.Sweep.createGraph();
+	 * const startSweep = sweepGraph.vertex('[start vertex]');
+	 * const endSweep = sweepGraph.vertex('[end vertex]');
+	 *
+	 * const path = mpSdk.Graph.createAStarRunner(sweepGraph, startSweep, endSweep).exec();
+	 * ```
+	 */
+	createGraph(): Promise<Graph.IDirectedGraph<Sweep.ObservableSweepData>>;
+	/**
+	 * An observable for the player's current sweep.
+	 *
+	 * If the camera is transitioning to or is currently in Dollhouse or Floorplan mode, or if the camera is transitioning between sweeps,
+	 * the `currentSweep` argument in the registered callback will be a "default" sweep that has an empty `sid` property.
+	 *
+	 * If the sweep is an unaligned, unplaced 360º view, `currentSweep.floorInfo.id` and `currentSweep.floorInfo.sequence` will both be `undefined`.
+	 *
+	 * Use this table with the results of `sid`, `floorInfo.sequence`, and `floorInfo.id` to determine the current of the three possible states.
+	 *
+	 * |                    | at sweep                | transitioning | in unplaced  360º view |
+	 * |--------------------|-------------------------|---------------|------------------------|
+	 * | sid                | `${current.sid}`        | ''            | `${current.sid}`       |
+	 * | floorInfo.sequence | `${floorInfo.sequence}` | undefined     | undefined              |
+	 * | floorInfo.id       | `${floorInfo.id}`       | undefined     | undefined              |
+	 *
+	 * ```
+	 * mpSdk.Sweep.current.subscribe(function (currentSweep) {
+	 *   // Change to the current sweep has occurred.
+	 *   if (currentSweep.sid === '') {
+	 *     console.log('Not currently stationed at a sweep position');
+	 *   } else {
+	 *     console.log('Currently at sweep', currentSweep.sid);
+	 *     console.log('Current position', currentSweep.position);
+	 *     console.log('On floor', currentSweep.floorInfo.sequence);
+	 *   }
+	 * });
+	 * ```
+	 *
+	 * You can also use this observable to wait until the user is in a sweep before executing additional code:
+	 *
+	 * ```typescript
+	 * await mpSdk.Sweep.current.waitUntil((currentSweep) => currentSweep.id !== '');
+	 * ```
+	 */
+	current: IObservable<Sweep.ObservableSweepData>;
+	/**
+	 * Move to a sweep.
+	 *
+	 *```
+	 * const sweepId = '1';
+	 * const rotation = { x: 30, y: -45 };
+	 * const transition = mpSdk.Sweep.Transition.INSTANT;
+	 * const transitionTime = 2000; // in milliseconds
+	 *
+	 * mpSdk.Sweep.moveTo(sweepId, {
+	 *     rotation: rotation,
+	 *     transition: transition,
+	 *     transitionTime: transitionTime,
+	 *   })
+	 *   .then(function(sweepId){
+	 *     // Move successful.
+	 *     console.log('Arrived at sweep ' + sweepId);
+	 *   })
+	 *   .catch(function(error){
+	 *     // Error with moveTo command
+	 *   });
+	 * ```
+	 *
+	 * @param The destination sweep.
+	 * @param Options.
+	 * @returns A promise that will return the destination sweep.
+	 */
+	moveTo(sweep: string, options: Sweep.MoveToOptions): Promise<string>;
+	/**
+	 * Enable a set of sweeps by ids.
+	 *
+	 * Enabling a sweep will show the sweep's puck and allow the player to navigate to that location.
+	 *
+	 * ```
+	 * mpSdk.Sweep.enable('sweep1', 'sweep2', 'sweep3');
+	 * ```
+	 *
+	 * @param sweepIds
+	 */
+	enable(...sweepIds: string[]): Promise<void>;
+	/**
+	 * Disable a set of sweeps by ids.
+	 *
+	 * Disabling a sweep will hide the sweep's puck and prevent the player's ability to navigate to that location.
+	 *
+	 *
+	 * ```
+	 * mpSdk.Sweep.disable('sweep1', 'sweep2', 'sweep3');
+	 * ```
+	 *
+	 * @param sweepIds
+	 */
+	disable(...sweepIds: string[]): Promise<void>;
+	/**
+	 * Add specified sweep IDs to the neighbors array
+	 *
+	 * This method allows changing the sweep connectivitiy to enable navigation from `sweepId`
+	 * to all sweeps in the `toAdd` array. Note that we use V2 IDs for all arguments. Refer
+	 * to Conversion.createIdMap() if you need to convert from the legacy V1 IDs.
+	 *
+	 * ```
+	 * Sweep.addNeighbors("hn7etcuyffbmqkyp5e43axa0b", ["zr7ns1smp51zibx4s239di7wb"]);
+	 * ```
+	 *
+	 * @param sweepId: string - Sweep ID
+	 * @param toAdd: string[] - List of Sweep IDs to connect
+	 * @returns A promise to a list of all current neighbor IDs (v2)
+	 */
+	addNeighbors(sweepId: string, toAdd: string[]): Promise<string[]>;
+	/**
+	 * Remove specified sweep IDs from the neighbors array
+	 *
+	 * This method allows changing the sweep connectivitiy to prevent navigation from `sweepId`
+	 * to all sweeps in the `toRemove` array. Note that we use V2 IDs for all arguments. Refer
+	 * to Conversion.createIdMap() if you need to convert from the legacy V1 IDs.
+	 *
+	 * ```
+	 * Sweep.removeNeighbors("hn7etcuyffbmqkyp5e43axa0b", ["zr7ns1smp51zibx4s239di7wb"]);
+	 * ```
+	 *
+	 * @param sweepId: string - Sweep ID
+	 * @param toRemove: string[] - List of Sweep IDs to disconnect
+	 * @returns A promise to a list of all current neighbor IDs (v2)
+	 */
+	removeNeighbors(sweepId: string, toRemove: string[]): Promise<string[]>;
+}
+export declare namespace Model {
+	type ModelData = {
+		sid: string;
+		/** @deprecated Use [[Sweep.data]] instead */
+		sweeps: Sweep.SweepData[];
+		modelSupportsVr: boolean;
+	};
+	type ModelDetails = {
+		sid: string;
+		name?: string;
+		presentedBy?: string;
+		summary?: string;
+		address?: string;
+		formattedAddress?: string;
+		contactEmail?: string;
+		contactName?: string;
+		phone?: string;
+		formattedContactPhone?: string;
+		shareUrl?: string;
+	};
+	enum Event {
+		/** @event */
+		MODEL_LOADED = "model.loaded"
+	}
+}
+export interface Model {
+	Event: typeof Model.Event;
+	/**
+	 * This function returns basic model information.
+	 *
+	 * This is no longer the canonical way to receive sweep information. See [[Sweep.data]].
+	 *
+	 * ```
+	 * mpSdk.Model.getData()
+	 *   .then(function(model) {
+	 *     // Model data retreival complete.
+	 *     console.log('Model sid:' + model.sid);
+	 *   })
+	 *   .catch(function(error) {
+	 *     // Model data retrieval error.
+	 *   });
+	 * ```
+	 */
+	getData(): Promise<Model.ModelData>;
+	/**
+	 * This function returns model details.
+	 *
+	 * ```
+	 * mpSdk.Model.getDetails()
+	 *   .then(function(modelDetails) {
+	 *     // Model details retreival complete.
+	 *     console.log('Model sid:' + modelDetails.sid);
+	 *     console.log('Model name:' + modelDetails.name);
+	 *     console.log('Model summary:' + modelDetails.summary);
+	 *   })
+	 *   .catch(function(error) {
+	 *     // Model details retrieval error.
+	 *   });
+	 * ```
+	 */
+	getDetails(): Promise<Model.ModelDetails>;
+}
+export declare namespace OAuth {
+	/**
+	 * An observer for events from a [[ITokenRefresher]]
+	 */
+	interface IRefreshObserver {
+		/** Observe successful token refresh events */
+		onRefresh?(): void;
+		/** Observe failures during token refresh */
+		onError?(e: Error): void;
+	}
+	/**
+	 * The token and expiry received from a call to the API
+	 */
+	interface TokenInfo {
+		access_token: string;
+		expires_in: number;
+	}
+	/**
+	 * A helper to tell the [[ITokenRefresher]] how to `fetch` a new token
+	 */
+	interface ITokenFetcher {
+		/** Fetch the new token. */
+		fetch(oldToken: string): Promise<TokenInfo>;
+	}
+	/**
+	 * A helper to automatically refresh tokens
+	 */
+	interface ITokenRefresher {
+		/**
+		 * Shut down, stop refreshing, and clean up resources
+		 */
+		dispose(): void;
+		/**
+		 * Listen for successful refreshes of the token
+		 * @param event The `'refresh'` event type
+		 * @param callback The callback to call on a refresh
+		 */
+		on(event: "refresh", callback: () => void): ISubscription;
+		/**
+		 * Listen for errors when refreshing the token
+		 * @param event The `'error'` event type
+		 * @param callback The callback to call on error
+		 */
+		on(event: "error", callback: (e: Error) => void): ISubscription;
+		/**
+		 * Attach an observer that can listen for refresh or error events
+		 * @param refreshObserver
+		 */
+		on(refreshObserver: OAuth.IRefreshObserver): ISubscription;
+	}
+}
+export interface OAuth {
+	/**
+	 * The [[ITokenRefresher]] constructor
+	 * ```
+	 */
+	createTokenRefresher(token: OAuth.TokenInfo, tokenFetcher: OAuth.ITokenFetcher): OAuth.ITokenRefresher;
+}
+export declare namespace Pointer {
+	export type Intersection = {
+		position: Vector3;
+		normal: Vector3;
+		/** @deprecated Use [[floorIndex]] instead */
+		floorId: number | undefined;
+		/**
+		 * floorIndex is only defined when the intersected object is MODEL.
+		 */
+		floorIndex: number | undefined;
+		object: Colliders;
+	};
+	export enum Colliders {
+		NONE = "intersectedobject.none",
+		MODEL = "intersectedobject.model",
+		TAG = "intersectedobject.tag",
+		SWEEP = "intersectedobject.sweep",
+		UNKNOWN = "intersectedobject.unknown"
+	}
+	type FadeOutProps = {
+		/**
+		 * Duration in milliseconds. Default is 700.
+		 */
+		duration?: number;
+		/**
+		 * Delay in milliseconds. Default is 700.
+		 */
+		delay?: number;
+	};
+	type FadeInProps = {
+		/**
+		 * Duration in milliseconds. Default is 300.
+		 */
+		duration?: number;
+	};
+	/**
+	 * Pointer reticle fade properties.
+	 */
+	export type FadeProps = {
+		fadeOut?: FadeOutProps;
+		fadeIn?: FadeInProps;
+	};
+	export {};
+}
+export interface Pointer {
+	Colliders: typeof Pointer.Colliders;
+	/**
+	 * An observable intersection data object that can be subscribed to.
+	 *
+	 * ```
+	 * mpSdk.Pointer.intersection.subscribe(function (intersectionData) {
+	 *  // Changes to the intersection data have occurred.
+	 *  console.log('Intersection position:', intersectionData.position);
+	 *  console.log('Intersection normal:', intersectionData.normal);
+	 * });
+	 * ```
+	 */
+	intersection: IObservable<Pointer.Intersection>;
+	/**
+	 * @introduced 3.1.55.2-34-ga9934ccd93
+	 * @deprecated Use [[Asset.registerTexture]] to register new textures instead.
+	 */
+	registerTexture(textureId: string, textureSrc: string): Promise<void>;
+	/**
+	 * Change the texture of the pointer reticle.
+	 *
+	 * ```typescript
+	 * await mpSdk.Asset.registerTexture('customTextureId', 'https://[link.to/image]');
+	 *
+	 * // change the texture of the pointer reticle using a previously registered id.
+	 * await mpSdk.Pointer.editTexture('customTextureId');
+	 * ```
+	 *
+	 * @param textureId The id of the texture to apply.
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.55.2-34-ga9934ccd93
+	 */
+	editTexture(textureId: string): Promise<void>;
+	/**
+	 * Resets the pointer reticle texture to the original texture.
+	 * ```typescript
+	 * await mpSdk.Pointer.resetTexture();
+	 * ```
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.55.2-34-ga9934ccd93
+	 */
+	resetTexture(): Promise<void>;
+	/**
+	 * Customizes the fade in/out behavior of the pointer reticle.
+	 * @param props face properties
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.55.2-34-ga9934ccd93
+	 */
+	setFadeProps(props: Pointer.FadeProps): Promise<void>;
+	/**
+	 * This function controls the visibility of the pointer reticle.
+	 * @param visible pointer reticle visibility
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.55.2-34-ga9934ccd93
+	 */
+	setVisible(visible: boolean): Promise<void>;
+}
+export declare namespace Renderer {
+	type Resolution = {
+		width: number;
+		height: number;
+	};
+	type Visibility = {
+		measurements: boolean;
+		mattertags: boolean;
+		sweeps: boolean;
+		views: boolean;
+	};
+	type WorldPositionData = {
+		position: Vector3 | null;
+		/** @deprecated Use [[floorInfo]] */
+		floor: number;
+		floorInfo: {
+			id: string;
+			sequence: number;
+		};
+	};
+}
+export interface Renderer {
+	/**
+	 * Takes a screenshot (JPEG) of the user’s current view.
+	 *
+	 * ```
+	 * const resolution = {
+	 *   width: 600,
+	 *   height: 800
+	 * };
+	 *
+	 * const visibility = {
+	 *   mattertags: false,
+	 *   sweeps: true
+	 * };
+	 *
+	 * mpSdk.Renderer.takeScreenShot(resolution, visibility)
+	 *   .then(function (screenShotUri) {
+	 *     // set src of an img element
+	 *     img.src = screenShotUri
+	 * });
+	 * ```
+	 *
+	 * @param resolution The desired resolution for the screenshot.
+	 * For example: `{width: 1920, height: 1080}`
+	 * If no resolution is specified, then the resolution of the size of
+	 * Showcase (the current window or the iframe embed) is used. Maximum 4096 x 4096.
+	 * @param visibility Toggles certain scene objects such as Mattertag Posts and sweep markers.
+	 * If no visibility object is specified, then all scene objects are hidden.
+	 * @return A promise that resolves with the screenshot URI -- a base64 encoded string which is usable as a src of an `<img>` element.
+	 *
+	 * **Errors**
+	 *
+	 * Warns if the resolution is 0 or negative.
+	 *
+	 */
+	takeScreenShot(resolution?: Renderer.Resolution, visibility?: Partial<Renderer.Visibility>): Promise<string>;
+	/**
+	 * Takes an equirectangular screenshot (JPEG) of the currently active sweep.
+	 *
+	 * ```
+	 * mpSdk.Renderer.takeEquirectangular()
+	 *   .then(function (screenShotUri) {
+	 *     // set src of an img element
+	 *     img.src = screenShotUri
+	 * });
+	 * ```
+	 *
+	 * @return A promise that resolves with the screenshot URI -- a base64 encoded string which is usable as a src of an `<img>` element.
+	 *
+	 * **Errors**
+	 *
+	 * Warns if the camera is not in Panorama mode and is instead in Dollhouse or Floorplan mode.
+	 *
+	 * **Notes**
+	 *
+	 * It is not on Matterport servers and does not persist between user sessions.
+	 */
+	takeEquirectangular(): Promise<string>;
+	/**
+	 * Converts a screen position into a world position
+	 *
+	 * If the height is not passed in, the function returns the first raycast hit in the direction of that screen position.
+	 * However, if there is no intersection with the model in that direction, the position will be null and the floor will be -1.
+	 *
+	 * ```
+	 * const screenPosition {x: 0, y: 0}; // Top left corner of the screen
+	 *
+	 * mpSdk.Renderer.getWorldPositionData(screenPosition)
+	 * .then(function(data){
+	 *    const worldPosition = data.position; // e.g. {x: 2.2323231, y: 4.7523232, z; 7.92893};
+	 *    const floor = data.floor; // e.g. 2
+	 * });
+	 * ```
+	 *
+	 * If the height is passed in, the function returns the intersection with the plane at that height. However,
+	 * if there is no intersection with the plane in that direction, the position will be null and the floor will be -1.
+	 *
+	 * ```
+	 * const screenPosition {x: 0, y: 0}; // Top left corner of the screen
+	 * const height = 20;
+	 *
+	 * mpSdk.Renderer.getWorldPositionData(screenPosition, height)
+	 * .then(function(data){
+	 *    const worldPosition = data.position; // e.g. {x: 2.2323231, y: 20, z; 7.92893};
+	 *    const floor = data.floor // e.g. 2
+	 * });
+	 * ```
+	 * @param {Vector2} screenPosition The screen position in pixels from the top-left corner of the screen.
+	 * For example, `{x: 300, y: 200}` would be the position 300 pixels right and 200 pixels down from the top-left corner.
+	 * @param {number} [height] Optional parameter for the height of the horizontal plane to intersect. If not provided, the
+	 * closest intersection with the model in that direction will be returned.
+	 * @param {boolean} [includeHiddenFloors] Optional parameter that will include floors that are hidden and ghosted
+	 * when determining the closest intersection with the model.
+	 *
+	 * **Notes**
+	 *
+	 * Returns null position if the direction of the screen position does not intersect with the model, or if a height was given,
+	 * if the the direction does not intersect with the plane at the given height.
+	 */
+	getWorldPositionData(screenPosition: Vector2, height?: number, includeHiddenFloors?: boolean): Promise<Renderer.WorldPositionData>;
+	/**
+	 * @deprecated Use [[Conversion.worldToScreen]] to convert a 3d position to a point on screen.
+	 */
+	getScreenPosition(worldPosition: Vector3): Promise<Vector2>;
+}
+export declare namespace Room {
+	type RoomData = {
+		id: string;
+		bounds: {
+			min: Vector3;
+			max: Vector3;
+		};
+		floorInfo: {
+			id: string;
+			sequence: number;
+		};
+		size: Vector3;
+		center: Vector3;
+	};
+	namespace Conversion {
+		/**
+		 * Generate a map between v2 IDs and v1 IDs
+		 *
+		 * This method will help with migration between IDs used for rooms.
+		 *
+		 * ```
+		 * const mapping = await mpSdk.Room.Conversion.createIdMap();
+		 * ```
+		 *
+		 * @param invert?: boolean - if passed, return map of v1->v2 instead
+		 */
+		function createIdMap(invert?: boolean): Promise<Dictionary<string>>;
+	}
+}
+export interface Room {
+	Conversion: typeof Room.Conversion;
+	/**
+	 * An observable to determine which rooms the player's camera is currently in.
+	 *
+	 * If the camera is in a location between rooms, or somehwere where our room bounds overlap, the `rooms` array will contain both (or more) rooms.
+	 * If the camera is in a mode other than `INSIDE`, the `rooms` array may be empty.
+	 * If the camera is in an unaligned sweep, the `rooms` array will be empty.
+	 *
+	 * ```
+	 * mpSdk.Room.current.subscribe(function (currentRooms) {
+	 *   if (currentRooms.rooms.length > 0) {
+	 *     console.log('currently in', currentRooms.rooms.length, 'rooms');
+	 *   } else {
+	 *     console.log('Not currently inside any rooms');
+	 *   }
+	 * });
+	 * ```
+	 */
+	current: IObservable<{
+		rooms: Room.RoomData[];
+	}>;
+	/**
+	 * An observable collection of Room data that can be subscribed to.
+	 *
+	 * See [[IObservableMap]] to learn how to receive data from the collection.
+	 *
+	 * ```
+	 * mpSdk.Room.data.subscribe({
+	 *   onCollectionUpdated: function (collection) {
+	 *     console.log('Collection received. There are ', Object.keys(collection).length, 'rooms in the collection');
+	 *   }
+	 * });
+	 * ```
+	 */
+	data: IObservableMap<Room.RoomData>;
+}
+/**
+ * Our Sensor system allows for generating spatial queries to understand a Matterport digital twin.
+ * By utilizing and setting up Sources around the scene, some questions that can be answered are:
+ * - "what things are currently visible on screen?"
+ * - "what things are near me?"
+ *
+ * where "things" can be Mattertag posts, sweeps, arbitrary locations (that you choose), or any combination of those.
+ */
+export declare namespace Sensor {
+	enum SensorType {
+		CAMERA = "sensor.sensortype.camera"
+	}
+	enum SourceType {
+		SPHERE = "sensor.sourcetype.sphere",
+		BOX = "sensor.sourcetype.box",
+		CYLINDER = "sensor.sourcetype.cylinder"
+	}
+	/**
+	 * A Sensor that detects Sources and provides information about the reading of each.
+	 */
+	interface ISensor extends IObservable<ISensor> {
+		/** The world-space position of the sensor. */
+		origin: Vector3;
+		/** The world-space "forward" direction describing which direction the sensor is facing. */
+		forward: Vector3;
+		/**
+		 * Add a source, to add its readings to the set of readings provided by `.subscribe`.
+		 * @param sources
+		 */
+		addSource(...sources: ISource[]): void;
+		/**
+		 * Start receiving updates when properties of this sensor change, e.g. `origin` or `forward`, not its `readings`.<br>
+		 * Subscribe to `readings` to receive updates about associated `ISources`
+		 */
+		subscribe<DataT>(observer: IObserver<DataT> | ObserverCallback<DataT>): ISubscription;
+		/**
+		 * An observable used to get information about assocated `ISources` added with [[ISensor.addSource]]
+		 */
+		readings: {
+			/**
+			 * Start receiving updates about the current set of sources added to this sensor.
+			 * @param observer
+			 */
+			subscribe(observer: ISensorObserver): ISubscription;
+		};
+		/**
+		 * Show debug visuals for this sensor. Existing visuals are disposed.
+		 * @param show
+		 */
+		showDebug(show: boolean): void;
+		/**
+		 * Teardown and cleanup the sensor, and stop receiving updates.
+		 */
+		dispose(): void;
+	}
+	type SphereVolume = {
+		/** The origin of the sphere. */
+		origin: Vector3;
+		/** The distance from origin of the sphere volume. */
+		radius: number;
+	};
+	type BoxVolume = {
+		/** The center position of the box. */
+		center: Vector3;
+		/** The length, width, and depth of the box volume. */
+		size: Vector3;
+		/** The orientation of the box. The rotations are applied in yaw, pitch, then roll order. */
+		orientation: Orientation;
+	};
+	type CylinderVolume = {
+		/** The point which defines the position (base) from which the height in the +Y, and radius in the XZ-plane are relative to. */
+		basePoint: Vector3;
+		/** The height of the cylinder. */
+		height: number;
+		/** The radius of the cylinder. */
+		radius: number;
+	};
+	/**
+	 * A Source represents a volume that will be detected by a Sensor.
+	 * The type of the source, describes the type of volume associated with it.
+	 * For example, with a `type` of `SourceType.SPHERE` the `volume` is a `SphereVolume`; a `SourceType.BOX` has a `BoxVolume`.
+	 */
+	interface ISource<Volume = SphereVolume | BoxVolume | CylinderVolume, UserData extends Record<string, unknown> = Record<string, unknown>> {
+		/** The type of source. */
+		type: SourceType;
+		/** The volume that represents the range of emissions from this `ISource`. */
+		volume: Volume;
+		/** Arbitrary data that can be used to set additional metadata, for example. */
+		userData: UserData;
+		/**
+		 * Let the sensor system know there is an update to this `ISource`.<br>
+		 * When changing any properties on `volume`, no changes will be reflected on the source or in Showcase until `commit` is called.
+		 */
+		commit(): Promise<void>;
+	}
+	/**
+	 * A specialized [[IMapObserver]] which maps an `ISource` to its current `SensorReading`.
+	 */
+	interface ISensorObserver {
+		/** Called when a the first `reading` is added from `source`. */
+		onAdded?(source: ISource, reading: SensorReading, collection: Map<ISource, SensorReading>): void;
+		/** Called when `source` and its `reading` is removed. */
+		onRemoved?(source: ISource, reading: SensorReading, collection: Map<ISource, SensorReading>): void;
+		/** Called when an existing `reading` is altered from `source`. */
+		onUpdated?(source: ISource, reading: SensorReading, collection: Map<ISource, SensorReading>): void;
+		/** Called when a set of changes happens within the `collection`. */
+		onCollectionUpdated?(collection: Map<ISource, SensorReading>): void;
+	}
+	/**
+	 * Information about the Source as read by the Sensor.
+	 */
+	type SensorReading = {
+		/** The sensor is currently within the broadcast range of the source. */
+		inRange: boolean;
+		/** The sensor is within the source's broadcast range and the sensor has clear line of sight to the source. */
+		inView: boolean;
+		/** The distance between the sensor and the source. */
+		distance: number;
+		/** The squared distance from the sensor to the source. */
+		distanceSquared: number;
+		/** The world-space direction from the sensor to the source. */
+		direction: Vector3;
+	};
+	/**
+	 * Additional `userData` to associate with an `ISource` when creating it.
+	 * This is a free dictionary that can contain any key/values deemed necessary.
+	 */
+	type SourceOptions<UserData extends Record<string, unknown> = Record<string, unknown>> = {
+		userData: UserData;
+	};
+}
+export interface Sensor {
+	SensorType: typeof Sensor.SensorType;
+	SourceType: typeof Sensor.SourceType;
+	/**
+	 * Create an [[`ISensor`]] which can sense and provide information about [[`ISource`]].
+	 *
+	 * ```typescript
+	 * const sensor = await mpSdk.Sensor.createSensor(mpSdk.Sensor.SensorType.CAMERA);
+	 * // add sources from calls to `Sensor.createSource()`
+	 * sensor.addSource(...sources);
+	 * // start listening for changes to the sensor's readings
+	 * sensor.readings.subscribe({
+	 *   onAdded(source, reading) {
+	 *     console.log(source.userData.id, 'has a reading of', reading);
+	 *   },
+	 *   onUpdated(source, reading) {
+	 *     console.log(source.userData.id, 'has an updated reading');
+	 *     if (reading.inRange) {
+	 *       console.log(source.userData.id, 'is currently in range');
+	 *       if (reading.inView) {
+	 *         console.log('... and currently visible on screen');
+	 *       }
+	 *     }
+	 *   }
+	 * });
+	 * ```
+	 */
+	createSensor(type: Sensor.SensorType.CAMERA): Promise<Sensor.ISensor>;
+	/**
+	 * Create a spherical [[`ISource`]] which can be sensed by an [[`ISensor`]].<br>
+	 * A shallow copy of `options.userData` is applied to the Source upon creation.
+	 *
+	 * Omitting `options.origin` will default the source's `volume.origin` to `{ x: 0, y: 0, z: 0 }`.<br>
+	 * Omitting `options.radius` will default the source's `volume.radius` to `Infinity`.
+	 *
+	 * ```typescript
+	 * const sources: Array<Sensor.ISource<Sensor.SphereVolume, { id: string }>> = await Promise.all([
+	 *   mpSdk.Sensor.createSource(mpSdk.Sensor.SourceType.SPHERE, {
+	 *     origin: { x: 1, y: 2, z: 3 },
+	 *     radius: 20,
+	 *     userData: {
+	 *       id: 'sphere-source-1',
+	 *     },
+	 *   }),
+	 *   mpSdk.Sensor.createSource(mpSdk.Sensor.SourceType.SPHERE, {
+	 *     radius: 4,
+	 *     userData: {
+	 *       id: 'sphere-source-2',
+	 *     },
+	 *   }),
+	 * ]);
+	 * // attach to a sensor previously created with `Sensor.createSensor()`
+	 * sensor.addSource(...sources);
+	 * ```
+	 * @param options
+	 */
+	createSource<UserData extends Record<string, unknown> = Record<string, unknown>>(type: Sensor.SourceType.SPHERE, options: Partial<Sensor.SphereVolume & Sensor.SourceOptions<UserData>>): Promise<Sensor.ISource<Sensor.SphereVolume, UserData>>;
+	/**
+	 * Create an box shaped [[`ISource`]] which can be sensed by an [[`ISensor`]].<br>
+	 * A shallow copy of `options.userData` is applied to the Source upon creation.
+	 *
+	 * Omitting `options.center` will default the source's `volume.center` to `{ x: 0, y: 0, z: 0 }`.<br>
+	 * Omitting `options.size` will default the source's `volume.size` to `{ x: Infinity, y: Infinity, z: Infinity }`.
+	 * Omitting `options.orientation` will default the source's `volume.orientatin` to `{ yaw: 0, pitch: 0, roll: 0 }`.
+	 *
+	 * ```typescript
+	 * const sources: Array<Sensor.ISource<Sensor.BoxVolume, { id: string }>> = await Promise.all([
+	 *   mpSdk.Sensor.createSource(mpSdk.Sensor.SourceType.BOX, {
+	 *     center: { x: 1, y: 1, z: 1 },
+	 *     size: { x: 2, y: 1, z: 2 },
+	 *     userData: {
+	 *       id: 'box-source-1',
+	 *     },
+	 *   }),
+	 *   mpSdk.Sensor.createSource(mpSdk.Sensor.SourceType.BOX, {
+	 *     size: { x: 2: y: 2, z: 2 },
+	 *     orientation: { yaw: 45, pitch: 45, roll: 45 },
+	 *     userData: {
+	 *       id: 'box-source-2',
+	 *     },
+	 *   }),
+	 * ]);
+	 * // attach to a sensor previously created with `Sensor.createSensor()`
+	 * sensor.addSource(...sources);
+	 * ```
+	 * @param options
+	 */
+	createSource<UserData extends Record<string, unknown> = Record<string, unknown>>(type: Sensor.SourceType.BOX, options: Partial<Sensor.BoxVolume & Sensor.SourceOptions<UserData>>): Promise<Sensor.ISource<Sensor.BoxVolume, UserData>>;
+	/**
+	 * Create a cylindrical [[`ISource`]] which can be sensed by an [[`ISensor`]].<br>
+	 * A shallow copy of `options.userData` is applied to the Source upon creation.
+	 *
+	 * Omitting `options.basePoint` will default the source's `volume.basePoint` to `{ x: 0, y: 0, z: 0 }`.<br>
+	 * Omitting `options.radius` will default the source's `volume.radius` to `Infinity`.<br>
+	 * Omitting `options.height` will default the source's `volume.height` to `Infinity`.
+	 *
+	 * ```typescript
+	 * const sources: Array<Sensor.ISource<Sensor.CylinderVolume, { id: string }>> = await Promise.all([
+	 *   mpSdk.Sensor.createSource(mpSdk.Sensor.SourceType.CYLINDER, {
+	 *     basePoint: { x: 0, y: 0, z: 0 },
+	 *     radius: 2,
+	 *     height: 5,
+	 *     userData: {
+	 *       id: 'cylinder-source-1',
+	 *     },
+	 *   }),
+	 *   mpSdk.Sensor.createSource(mpSdk.Sensor.SourceType.CYLINDER, {
+	 *     basePoint: { x: 1, y: 2, z: 3 },
+	 *     radius: 3,
+	 *     userData: {
+	 *       id: 'cylinder-source-2',
+	 *     },
+	 *   }),
+	 * ]);
+	 * // attach to a sensor previously created with `Sensor.createSensor()`
+	 * sensor.addSource(...sources);
+	 * ```
+	 */
+	createSource<UserData extends Record<string, unknown> = Record<string, unknown>>(type: Sensor.SourceType.CYLINDER, options: Partial<Sensor.CylinderVolume & Sensor.SourceOptions<UserData>>): Promise<Sensor.ISource<Sensor.CylinderVolume, UserData>>;
+}
+export declare namespace Settings { }
+export interface Settings {
+	/**
+	 * This function returns the value of a setting if it exists, if it does not currently exist, it will return undefined.
+	 *
+	 * ```
+	 * mpSdk.Settings.get('labels')
+	 *   .then(function(data) {
+	 *     // Setting retrieval complete.
+	 *     console.log('Labels setting: ' + data);
+	 *   })
+	 *   .catch(function(error) {
+	 *     // Setting  retrieval error.
+	 *   });
+	 * ```
+	 */
+	get(key: string): Promise<any | undefined>;
+	/**
+	 * This function updates the value of a setting if it exists, returning the new value when it is set
+	 *
+	 * ```
+	 * mpSdk.Settings.update('labels', false)
+	 *   .then(function(data) {
+	 *     // Setting update complete.
+	 *     console.log('Labels setting: ' + data);
+	 *   })
+	 *   .catch(function(error) {
+	 *     // Setting update error.
+	 *   });
+	 * ```
+	 */
+	update(key: string, value: any): Promise<void>;
+}
+export declare namespace Tag {
+	enum AttachmentType {
+		/** An unknown type of attachment. This should never happen */
+		UNKNOWN = "tag.attachment.unknown",
+		APPLICATION = "tag.attachment.application",
+		AUDIO = "tag.attachment.audio",
+		/** The attachment contains an image */
+		IMAGE = "tag.attachment.image",
+		/** The attachment contains rich content like an iframe of another site */
+		MODEL = "tag.attachment.model",
+		PDF = "tag.attachment.pdf",
+		RICH = "tag.attachment.rich",
+		TEXT = "tag.attachment.text",
+		/** The attachment contains a video */
+		VIDEO = "tag.attachment.video",
+		ZIP = "tag.attachment.zip",
+		/** The attachment is a sandbox created by a call to [[Tag.registerSandbox]] */
+		SANDBOX = "tag.attachment.sandbox"
+	}
+	type TagData = {
+		id: string;
+		anchorPosition: Vector3;
+		discPosition: Vector3;
+		stemVector: Vector3;
+		stemHeight: number;
+		stemVisible: boolean;
+		label: string;
+		description: string;
+		color: Color;
+		roomId: string;
+		/** The ids of the attachments currently attached to this tag */
+		attachments: string[];
+		keywords: string[];
+		/** Read-only Font Awesome id for icons set in workshop, e.g. "face-grin-tongue-squint"
+		 * This value does not change if [[Tag.editIcon]] is used. This value is an empty string if no fontId was set.
+		*/
+		fontId: string;
+	};
+	/**
+	 * Things such as media, etc that can be attached to a Tag.
+	 * Attachments are the new equivalent to Media in Mattertags.
+	 */
+	type Attachment = {
+		id: string;
+		src: string;
+		type: AttachmentType;
+	};
+	/**
+	 * A subset of the TagData used when adding Tags.
+	 * Most properties are optional except those used for positioning: `anchorPosition`, `stemVector`.
+	 */
+	type Descriptor = {
+		id?: string;
+		anchorPosition: Vector3;
+		stemVector: Vector3;
+		stemVisible?: boolean;
+		label?: string;
+		description?: string;
+		color?: Color;
+		opacity?: number;
+		iconId?: string;
+		attachments?: string[];
+	};
+	type PositionOptions = {
+		anchorPosition: Vector3;
+		stemVector: Vector3;
+		roomId: string;
+	};
+	type StemHeightEditOptions = {
+		stemHeight: number;
+		stemVisible: boolean;
+	};
+	type EditableProperties = {
+		label: string;
+		description: string;
+	};
+	type SandboxOptions = {
+		/**
+		 * A map for the three global functions we provide in your sandbox.
+		 * Only needs to be used if scripts you are importing also have a global `send`, `on`, `off`, `tag`, or `docked`.
+		 */
+		globalVariableMap: GlobalVariableMap;
+		/**
+		 * A human readable name that will be used as the `src` in the attachments collection.
+		 */
+		name: string;
+		/**
+		 * The size of the sandbox to display
+		 * Providing `0` as one of the dimensions will instead use the default: 150px for height, 100% for width.
+		 */
+		size: Size;
+	};
+	/**
+	 * Map the globals we provide in your sandbox to other names.
+	 */
+	type GlobalVariableMap = {
+		send?: string;
+		on?: string;
+		off?: string;
+		tag?: string;
+		docked?: string;
+	};
+	/**
+	 * A messaging object to send and receive messages to and from your iframe sandbox.
+	 */
+	interface IMessenger {
+		/**
+		 * Send a messages of type `eventType` to the iframe sandbox with any optional data associated with the message
+		 */
+		send(eventType: string, ...args: any[]): void;
+		/**
+		 * Add a handler for messages of type `eventType` from the iframe sandbox
+		 */
+		on(eventType: string, eventHandler: (...args: any[]) => void): void;
+		/**
+		 * Remove a handler for messages of type `eventType` from the iframe sandbox
+		 */
+		off(eventType: string, eventHandler: (...args: any[]) => void): void;
+	}
+	/**
+	 * The actions that can be taken when interacting with a tag
+	 */
+	type AllowableActions = {
+		/** Whether the tag can be opened via a mouse hover */
+		opening: boolean;
+		/** Whether navigation towared the tag will occur when clicked */
+		navigating: boolean;
+		/** Whether the tag can be docked */
+		docking: boolean;
+		/** Whether the tag has a share button */
+		sharing: boolean;
+	};
+	type OpenOptions = {
+		/** Force the tag open regardless of whether its allowed from previous calls to [[Tag.allowAction]] */
+		force: boolean;
+	};
+	type OpenTags = {
+		/** The id of the tag that is currently being previewed or hovered over. */
+		hovered: string | null;
+		/** The set of ids of tags that are currently "stuck" open like from a click action. Currently, this is limited to just one tag. */
+		selected: Set<string>;
+		/** The id of the tag that is currently docked. */
+		docked: string | null;
+	};
+}
+export interface Tag {
+	AttachmentType: typeof Tag.AttachmentType;
+	/**
+	 * An observable collection of the [[Attachment]].
+	 *
+	 * ```typescript
+	 * mpSdk.Tag.attachments.subscribe({
+	 *   onAdded: function (index, item, collection) {
+	 *     console.log('An attachment was added to the collection', index, item, collection);
+	 *   },
+	 *   onCollectionUpdated(collection) {
+	 *     console.log('The entire collection of attachments', collection);
+	 *   },
+	 * });
+	 * ```
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.68.12-7-g858688944a
+	 */
+	attachments: IObservableMap<Tag.Attachment>;
+	/**
+	 * Attach [[Attachment]] to a Tag.
+	 *
+	 * ```typescript
+	 * const tagId: string; // ... acquired through a previous call to `mpSdk.Tag.add` or through `mpSdk.Tag.data`
+	 * const attachmentIds: string[]; // ... acquired through a previous call to `mpSdk.Tag.registerAttachment` or through `mpSdk.Tag.attachments`
+	 *
+	 * mpSdk.Tag.attach(tagId, ...attachmentIds);
+	 * // or
+	 * mpSdk.Tag.attach(tagId, attachmentId[0], attachmentId[1]);
+	 * ```
+	 *
+	 * @param tagId
+	 * @param attachmentId
+	 * @return A promise that resolves when the Attachment is added to the Tag
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.68.12-7-g858688944a
+	 */
+	attach(tagId: string, ...attachmentIds: string[]): Promise<void>;
+	/**
+	 * Detach [[Attachment]] from a Tag.
+	 *
+	 * ```typescript
+	 * const tagId: string; // ... acquired through a previous call to `mpSdk.Tag.add` or through `mpSdk.Tag.data`
+	 * const attachmentIds: string[]; // ... acquired through a previous call to `mpSdk.Tag.registerAttachment` or through `mpSdk.Tag.attachments`
+	 *
+	 * mpSdk.Tag.detach(tagId, ...attachmentIds);
+	 * // or
+	 * mpSdk.Tag.detach(tagId, attachmentId[0], attachmentId[1]);
+	 * ```
+	 *
+	 * @param tagId
+	 * @param attachmentIds
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.70.10-0-ge9cb83b28c
+	 */
+	detach(tagId: string, ...attachmentIds: string[]): Promise<void>;
+	/**
+	 * Register a new [[Attachment]] that can later be attached as media to a Tag.
+	 *
+	 * Custom HTML can be added as an attachment through the use of [[registerSandbox]] instead.
+	 *
+	 * ```typescript
+	 * // register a couple of attachments to use later
+	 * const [attachmentId1, attachmentId2] = mpSdk.Tag.registerAttachment(
+	 *   'https://[link.to/media]',
+	 *   'https://[link.to/other_media]',
+	 * );
+	 * ```
+	 * @param srcs The src URLs of the media
+	 * @return A promise that resolves to an array of ids associated with the newly added Attachments
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.68.12-7-g858688944a
+	 */
+	registerAttachment(...srcs: string[]): Promise<string[]>;
+	/**
+	 * Register an HTML sandbox that diplays custom HTML and runs custom scripts as an attachment.
+	 * Data can be sent and received from the sandbox by using the returned [[IMessenger]].
+	 *
+	 * ```typescript
+	 * const htmlToInject = `
+	 *   <style>
+	 *     button {
+	 *       width: 100px;
+	 *       height: 50px;
+	 *     }
+	 *   </style>
+	 *   <button id='btn1'>CLICK ME</button>
+	 *   <script>
+	 *     var btn1 = document.getElementById('btn1');
+	 *     btn1.addEventListener('click', () => {
+	 *       // send data out of the sandbox
+	 *       window.send('buttonClick', 12345);
+	 *     });
+	 *     // receive data from outside of the sandbox
+	 *     window.on('updateButton', (newLabel, color) => {
+	 *       btn1.innerText = newLabel;
+	 *       btn1.style.backgroundColor = color;
+	 *     });
+	 *   </script>
+	 * `;
+	 *
+	 * // create and register the sandbox
+	 * const [sandboxId, messenger] = await mpSdk.Tag.registerSandbox(htmlToInject);
+	 * // attach the sandbox to a tag
+	 * mpSdk.Tag.attach(tagId, sandboxId);
+	 * // receive data from the sandbox
+	 * messenger.on('buttonClick', (buttonId) => {
+	 *   console.log('clicked button with id:', buttonId);
+	 * });
+	 * // send data to the sandbox
+	 * messenger.send('I send messages', 'red');
+	 * ```
+	 *
+	 * @param html
+	 * @param options
+	 * @returns An [[IMessenger]] that can be used to communicate with the sandbox by sending and receiving data
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.70.10-0-ge9cb83b28c
+	 */
+	registerSandbox(html: string, options?: Partial<Tag.SandboxOptions>): Promise<[
+		string,
+		Tag.IMessenger
+	]>;
+	/**
+	 * An observable collection of Tag data that can be subscribed to.
+	 *
+	 * When first subscribing, the current set of Tags will call the observer's `onAdded` for each Tag as the data becomes available.
+	 *
+	 * ```typescript
+	 * mpSdk.Tag.data.subscribe({
+	 *   onAdded(index, item, collection) {
+	 *     console.log('Tag added to the collection', index, item, collection);
+	 *   },
+	 *   onRemoved(index, item, collection) {
+	 *     console.log('Tag removed from the collection', index, item, collection);
+	 *   },
+	 *   onUpdated(index, item, collection) {
+	 *     console.log('Tag updated in place in the collection', index, item, collection);
+	 *   },
+	 *   onCollectionUpdated(collection) {
+	 *     console.log('The full collection of Tags looks like', collection);
+	 *   }
+	 * });
+	 * ```
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.68.12-7-g858688944a
+	 */
+	data: IObservableMap<Tag.TagData>;
+	/**
+	 * An observable state of that tags that are hovered, selected, or docked.
+	 * A Tag can be in all three states at once. A docked tag is also always considered selected.
+	 *
+	 * ```typescript
+	 * mpSdk.Tag.openTags.subscribe({
+	 *   prevState: {
+	 *     hovered: null,
+	 *     docked: null,
+	 *     selected: null,
+	 *   },
+	 *   onChanged(newState) {
+	 *     if (newState.hovered !== this.prevState.hovered) {
+	 *       if (newState.hovered) {
+	 *         console.log(newState.hovered, 'was hovered');
+	 *       } else {
+	 *         console.log(this.prevState.hovered, 'is no longer hovered');
+	 *       }
+	 *     }
+	 *     if (newState.docked !== this.prevState.docked) {
+	 *       if (newState.docked) {
+	 *         console.log(newState.docked, 'was docked');
+	 *       } else {
+	 *         console.log(this.prevState.docked, 'was undocked');
+	 *       }
+	 *     }
+	 *
+	 *     // only compare the first 'selected' since only one tag is currently supported
+	 *     const [selected = null] = newState.selected; // destructure and coerce the first Set element to null
+	 *     if (selected !== this.prevState.selected) {
+	 *         if (selected) {
+	 *             console.log(selected, 'was selected');
+	 *         } else {
+	 *             console.log(this.prevState.selected, 'was deselected');
+	 *         }
+	 *     }
+	 *
+	 *     // clone and store the new state
+	 *     this.prevState = {
+	 *       ...newState,
+	 *       selected,
+	 *     };
+	 *   },
+	 * });
+	 * ```
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 23.2.1
+	 */
+	openTags: IObservable<Tag.OpenTags>;
+	/**
+	 * Add one or more Tags to Showcase.
+	 * Each input Tag supports setting the label, description, color or icon, anchorPosition, stemVector, and attachments.
+	 *
+	 * Two properties are required:
+	 * - `anchorPosition`, the point where the tag connects to the model
+	 * - `stemVector`, the direction, aka normal, and height that the Tag stem points
+	 *
+	 * See [[Pointer.intersection]] for a way to retrieve a new `anchorPosition` and `stemVector`.
+	 *
+	 * **Note**: these changes are not persisted between refreshes of Showcase. They are only valid for the current browser session.
+	 * They also do not have "share" buttons as they associated with them.
+	 *
+	 * ```typescript
+	 * mpSdk.Tag.add({
+	 *  label: 'New tag',
+	 *  description: 'This tag was added through the Matterport SDK',
+	 *  anchorPosition: {
+	 *    x: 0,
+	 *    y: 0,
+	 *    z: 0,
+	 *  },
+	 *  stemVector: { // make the Tag stick straight up and make it 0.30 meters (~1 foot) tall
+	 *    x: 0,
+	 *    y: 0.30,
+	 *    z: 0,
+	 *  },
+	 *  color: { // blue disc
+	 *    r: 0.0,
+	 *    g: 0.0,
+	 *    b: 1.0,
+	 *  },
+	 * }, {
+	 *  label: 'New tag 2',
+	 *  anchorPosition: {
+	 *    x: 1,
+	 *    y: 2,
+	 *    z: 3,
+	 *  },
+	 *  stemVector: {
+	 *    x: ,
+	 *    y: ,
+	 *    z: ,
+	 *  }
+	 * });
+	 * ```
+	 *
+	 * @param tags The descriptors for all Tags to be added.
+	 * @returns A promise that resolves with the array of ids for the newly added Tags.
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.68.12-7-g858688944a
+	 */
+	add(...tags: Tag.Descriptor[]): Promise<string[]>;
+	/**
+	 * Sets the allowed "default" Showcase actions on a Tag from occurring: hover to open billboard, click to navigate to view.
+	 * If an action is ommited from the actions argument, it will be considered false by default.
+	 *
+	 * ```typescript
+	 * const tagIds: string[]; // ... acquired through previous calls to `mpSdk.Tag.add` or through `mpSdk.Tag.data`
+	 *
+	 * // prevent navigating to the tag on click
+	 * const noNavigationTag = tagIds[0];
+	 * mpSdk.Tag.allowAction(noNavigationTag, {
+	 *   opening: true,
+	 *   // implies navigating: false, etc
+	 * });
+	 *
+	 * // prevent the billboard from showing
+	 * const noBillboardTag = tagIds[1];
+	 * mpSdk.Tag.allowAction(noBillboardTag, {
+	 *   navigating: true,
+	 *   // implies opening: false, etc
+	 * });
+	 *
+	 * const noActionsTag = tagIds[2];
+	 * mpSdk.Tag.allowAction(noActionsTag, {
+	 *   // implies opening: false and navigating: false, etc
+	 * });
+	 * ```
+	 *
+	 * @param id The id of the Tag to change the allowed actions
+	 * @param actions The set of actions allowed on the Tag
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.68.12-7-g858688944a
+	 */
+	allowAction(id: string, actions: Partial<Tag.AllowableActions>): Promise<void>;
+	/**
+	 * Open a tag and display its billboard.
+	 * Opening a second tag will close the first.
+	 *
+	 * ```typescript
+	 * mpSdk.Tag.open(tagId);
+	 *
+	 * // if the tag has had its `dock` option removed through a call to `Tag.allowAction`, it can be `force`d open
+	 * mpSdk.Tag.allowAction(tagId, {
+	 *   opening: false,
+	 * });
+	 * mpSdk.Tag.open(tagId,
+	 *   force: true,
+	 * });
+	 * ```
+	 *
+	 * @param id
+	 * @param options
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 23.2.1
+	 */
+	open(id: string, options?: Partial<Tag.OpenOptions>): Promise<void>;
+	/**
+	 * Close a tag and its billboard or dock.
+	 *
+	 * ```typescript
+	 * const tagId: string; // ... acquired through previous calls to `mpSdk.Tag.add` or through `mpSdk.Tag.data`
+	 * mpSdk.Tag.open(tagId);
+	 * mpSdk.Tag.close(tagId);
+	 * ```
+	 *
+	 * @param id
+	 * @embed
+	 * @bundle
+	 * @introduced 23.2.1
+	 */
+	close(id: string): Promise<void>;
+	/**
+	 * Open a tag in the docked view.
+	 *
+	 * ```typescript
+	 * const tagId: string; // ... acquired through previous calls to `mpSdk.Tag.add` or through `mpSdk.Tag.data`
+	 * mpSdk.Tag.dock(tagId);
+	 * ```
+	 *
+	 * @param id
+	 * @param options
+
+	 * @embed
+	 * @bundle
+	 * @introduced 23.2.1
+	 */
+	dock(id: string, options?: Partial<Tag.OpenOptions>): Promise<void>;
+	/**
+	 * Edit the text content in a Tag's billboard.
+	 *
+	 * **Note**: these changes are not persisted between refreshes of Showcase. They are only valid for the current browser session.
+	 *
+	 * ```typescript
+	 * mpSdk.Tag.editBillboard(id, {
+	 *   label: 'This is a new title',
+	 *   description: 'This image was set dynamically by the Showcase sdk',
+	 * });
+	 * ```
+	 * @param id the id of the Tag to edit
+	 * @param properties A dictionary of properties to set
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.68.12-7-g858688944a
+	 */
+	editBillboard(id: string, properties: Partial<Tag.EditableProperties>): Promise<void>;
+	/**
+	 * Edit the color of a Tag's disc.
+	 *
+	 * ```typescript
+	 * const tagIds: string[]; // ... acquired through previous calls to `mpSdk.Tag.add` or through `mpSdk.Tag.data`
+	 *
+	 * // change the first Tag to yellow
+	 * mpSdk.Tag.editColor(tagIds[0], {
+	 *   r: 0.9,
+	 *   g: 0,
+	 *   b: 0.9,
+	 * });
+	 * ```
+	 *
+	 * @param id The id of the Tag to edit
+	 * @param color The new color to be applied to the Tag disc
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.68.12-7-g858688944a
+	 */
+	editColor(id: string, color: Color): Promise<void>;
+	/**
+	 * Change the icon of the Tag disc. Icons can be registered asset textures or font ids provided by the player.
+	 * Supported font ids can be found at https://matterport.github.io/showcase-sdk/tags_icons_reference.html.
+	 *
+	 * **Note**: these changes are not persisted between refreshes of Showcase. They are only valid for the current browser session.
+	 *
+	 * ```typescript
+	 * // change the icon of the Tag using the id used in a previous `Asset.registerTexture` call
+	 * mpSdk.Tag.editIcon(id, 'customIconId');
+	 * ```
+	 *
+	 * ```typescript
+	 * // change the icon of the Tag to a font id.
+	 * mpSdk.Tag.editIcon(id, 'public_buildings_apartment');
+	 * ```
+	 *
+	 * @param tagId The id of the Tag to edit
+	 * @param iconId The id of the icon to apply
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.68.12-7-g858688944a
+	 */
+	editIcon(tagId: string, iconId: string): Promise<void>;
+	/**
+	 * Edit the opacity of a Tag.
+	 *
+	 * A completely transparent/invisible Tag is still interactable and will respond to mouse hovers and clicks.
+	 *
+	 * ```typescript
+	 * const tagIds: string[]; // ... acquired through previous calls to `mpSdk.Tag.add` or through `mpSdk.Tag.data`
+	 * // make the first Tag invisible
+	 * mpSdk.Tag.editOpacity(tagIds[0], 0);
+	 *
+	 * // make another Tag transparent
+	 * mpSdk.Tag.editOpacity(tagIds[1], 0.5);
+	 *
+	 * // and another completely opaque
+	 * mpSdk.Tag.editOpacity(tagIds[2], 1);
+	 * ```
+	 *
+	 * @param id The id of the Tag to edit
+	 * @param opacity The target opacity for the Tag in the range of [0, 1]
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.68.12-7-g858688944a
+	 */
+	editOpacity(id: string, opacity: number): Promise<void>;
+	/**
+	 * Edit the stem of a Tag
+	 *
+	 * ```typescript
+	 * const tagId: string = tagData[0].id; // ... acquired through a previous call to `mpSdk.Tag.add` or through `mpSdk.Tag.data`
+	 *
+	 * // make the first Tag have an invsible stem
+	 * mpSdk.Tag.editStem(tagId, {stemVisible: false});
+	 *
+	 * // make another Tag have a long stem
+	 * mpSdk.Tag.editStem(tagId, {stemHeight: 1});
+	 * ```
+	 *
+	 * @param tagSid The sid of the Tag to edit
+	 * @param stemOptions What to change about the Tag's stem - can include stemHeight and stemVisible
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.70.10-0-ge9cb83b28c
+	 */
+	editStem(tagSid: string, options: Partial<Tag.StemHeightEditOptions>): Promise<void>;
+	/**
+	 * Move and reorient a Tag.
+	 *
+	 * See [[Pointer.intersection]] for a way to retrieve a new `anchorPosition` and `stemVector`.
+	 *
+	 * **Note**: these changes are not persisted between refreshes of Showcase. They are only valid for the current browser session.
+	 *
+	 * ```typescript
+	 * const tagId: string; // ... acquired through a previous call to `mpSdk.Tag.add` or through `mpSdk.Tag.data`
+	 *
+	 * mpSdk.Tag.editPosition(tagId, {
+	 *  anchorPosition: {
+	 *    x: 0,
+	 *    y: 0,
+	 *    z: 0,
+	 *  },
+	 *  stemVector: { // make the Tag stick straight up and make it 0.30 meters (~1 foot) tall
+	 *    x: 0,
+	 *    y: 0.30,
+	 *    z: 0,
+	 *  },
+	 * });
+	 * ```
+	 * @param id The id of the Tag to reposition
+	 * @param options The new anchorPosition, stemVector and/or roomId to associate the tag with.
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.68.12-7-g858688944a
+	 */
+	editPosition(id: string, options: Partial<Tag.PositionOptions>): Promise<void>;
+	/**
+	 * Removes one or more Tags from Showcase.
+	 *
+	 * **Note**: these changes are not persisted between refreshes of Showcase. They are only valid for the current browser session.
+	 *
+	 * ```typescript
+	 * const tagIds: string[]; // ... acquired through a previous call to `mpSdk.Tag.add` or through `mpSdk.Tag.data`
+	 * // remove one tag
+	 * mpSdk.Tag.remove(tagIds[0]);
+	 *
+	 * // or remove multiple at the same time
+	 * mpSdk.Tag.remove(...tagIds);
+	 * ```
+	 * @param ids The Tags' ids to be removed.
+	 * @returns A promise with an array of Tag ids that were actually removed.
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.68.12-7-g858688944a
+	 */
+	remove(...ids: string[]): Promise<string[]>;
+	/**
+	 * Resets the icon of the Tag disc back to its original icon.
+	 *
+	 * ```typescript
+	 * const tagIds: string[]; // ... acquired through a previous call to `mpSdk.Tag.add` or through `mpSdk.Tag.data`
+	 *
+	 * // reset the icon of the first Tag to its original
+	 * mpSdk.Tag.resetIcon(tagIds[0].id);
+	 * ```
+	 *
+	 * @param id The id of the Tag to reset
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.68.12-7-g858688944a
+	 */
+	resetIcon(id: string): Promise<void>;
+	/**
+	 * Toggle the overhead navigation UI
+	 *
+	 * ```typescript
+	 * // hide the controls
+	 * mpSdk.Tag.toggleNavControls(false);
+	 *
+	 * // show the controls
+	 * mpSdk.Tag.toggleNavControls(true);
+	 *
+	 * // toggle the current visibility of the controls
+	 * mpSdk.Tag.toggleNavControls();
+	 * ```
+	 * @param enable
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 23.3.1
+	 */
+	toggleNavControls(enable?: boolean): Promise<void>;
+	/**
+	 * Toggle the dock setting to hide dock buttons in all tags.
+	 *
+	 * Disabling the dock setting will remove the dock buttons from all tags.
+	 * Enabling the dock setting does not automatically show the dock button in all tags.
+	 * The dock button will only be displayed in a tag if both the dock setting is true and docking is allowed by the tag (see [[Tag.allowAction]]).
+	 *
+	 * ```typescript
+	 * // hide the dock buttons
+	 * mpSdk.Tag.toggleDocking(false);
+	 *
+	 * // show the dock buttons
+	 * mpSdk.Tag.toggleDocking(true);
+	 *
+	 * // toggle the current visibility of the dock buttons
+	 * mpSdk.Tag.toggleDocking();
+	 * ```
+	 * @param enable
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 23.4.2
+	 */
+	toggleDocking(enable?: boolean): Promise<void>;
+	/**
+	 * Toggle the share setting to hide share buttons in all tags.
+	 *
+	 * Disabling the share setting will remove the share buttons from all tags.
+	 * Enabling the share setting does not automatically show the share button in all tags.
+	 * The share button will only be displayed in a tag if both the share setting is true and sharing is allowed by the tag (see [[Tag.allowAction]]).
+	 *
+	 * ```typescript
+	 * // hide the share buttons
+	 * mpSdk.Tag.toggleSharing(false);
+	 *
+	 * // show the share buttons
+	 * mpSdk.Tag.toggleSharing(true);
+	 *
+	 * // toggle the current visibility of the share buttons
+	 * mpSdk.Tag.toggleSharing();
+	 * ```
+	 * @param enable
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 23.4.2
+	 */
+	toggleSharing(enable?: boolean): Promise<void>;
+}
+declare namespace Test {
+	namespace Sub {
+		/**
+		 * Call an asynchronous command with a parameter and get the same value back.
+		 * @param arg
+		 */
+		function echo(arg: string): Promise<string>;
+		/**
+		 * Call an asynchronous command with a parameter and get the same value back.
+		 * @param arg
+		 */
+		function echoAsync(arg: string): Promise<string>;
+		namespace Sub2 {
+			/**
+			 * Call an asynchronous command with a parameter and get the same value back.
+			 * @param arg
+			 */
+			function echo(arg: string): Promise<string>;
+			/**
+			 * Call an asynchronous command with a parameter and get the same value back.
+			 * @param arg
+			 */
+			function echoAsync(arg: string): Promise<string>;
+		}
+	}
+}
+interface Test {
+	/**
+	 * Call a synchronous command with a parameter and get the same value back.
+	 * @param arg
+	 */
+	echo(arg: string): Promise<string>;
+	/**
+	 * Call an asynchronous command with a parameter and get the same value back.
+	 * @param arg
+	 */
+	echoAsync(arg: string): Promise<string>;
+	/**
+	 * A sub-namespace that simply namespaces and sub-namespaces the functions in this interface
+	 */
+	Sub: {
+		echo: typeof Test.Sub.echo;
+		echoAsync: typeof Test.Sub.echoAsync;
+		Sub2: {
+			echo: typeof Test.Sub.Sub2.echo;
+			echoAsync: typeof Test.Sub.Sub2.echoAsync;
+		};
+	};
+}
+/**
+ * Sample custom tour.
+ *
+ * ```
+ * const connect = function(sdk) {
+ *   const mpSdk = sdk;
+ *
+ *   mpSdk.Tour.Event.on(Tour.Event.STEPPED, function(tourIndex){
+ *     console.log('Tour index ' + tourIndex);
+ *   });
+ *   mpSdk.Tour.Event.on(Tour.Event.STARTED, function(){
+ *     console.log('Tour started');
+ *   });
+ *   mpSdk.Tour.Event.on(Tour.Event.STOPPED, function(){
+ *     console.log('Tour stopped');
+ *   });
+ *
+ *   mpSdk.Tour.getData()
+ *     .then(function(tour) {
+ *       console.log('tour has ' + tour.length + ' stops');
+ *       return mpSdk.Tour.start(0);
+ *     })
+ *     .then(function(){
+ *       // console 'Tour started'
+ *       // console -> 'Tour index 0'
+ *       return mpSdk.Tour.next();
+ *     })
+ *     .then(function(){
+ *       // console -> 'Tour index 1'
+ *       return mpSdk.Tour.step(3);
+ *     })
+ *     .then(function(){
+ *       // console -> 'Tour index 3'
+ *       return mpSdk.Tour.prev();
+ *     })
+ *     .then(function(){
+ *       // console -> 'Tour index 2'
+ *       // console -> 'Tour stopped'
+ *       return mpSdk.Tour.stop();
+ *     });
+ * }
+ * ```
+ *
+ */
+export declare namespace Tour {
+	type Snapshot = {
+		sid: string;
+		thumbnailUrl: string;
+		imageUrl: string;
+		is360: boolean;
+		name: string;
+		mode: Mode.Mode | undefined;
+		position: Vector3;
+		rotation: Vector3;
+		zoom: number;
+	};
+	enum Event {
+		/** @event */
+		STARTED = "tour.started",
+		/** @event */
+		STOPPED = "tour.stopped",
+		/** @event */
+		ENDED = "tour.ended",
+		/** @event */
+		STEPPED = "tour.stepped"
+	}
+	type CurrentStepData = {
+		step: string | null;
+	};
+	enum PlayState {
+		INACTIVE = "tour.inactive",
+		ACTIVE = "tour.active",
+		STOP_SCHEDULED = "tour.stopscheduled"
+	}
+	type CurrentStateData = {
+		current: PlayState;
+	};
+	type CurrentTransitionData = {
+		from: string | null;
+		to: string | null;
+	};
+}
+export declare interface Tour {
+	Event: typeof Tour.Event;
+	PlayState: typeof Tour.PlayState;
+	/**
+	 * This function starts the tour.
+	 *
+	 * ```
+	 * const tourIndex = 1;
+	 *
+	 * mpSdk.Tour.start(tourIndex)
+	 *   .then(function() {
+	 *     // Tour start complete.
+	 *   })
+	 *   .catch(function(error) {
+	 *     // Tour start error.
+	 *   });
+	 * ```
+	 *
+	 * @embed
+	 * @bundle
+	 */
+	start(index?: number): Promise<void>;
+	/**
+	 * This function stops the tour.
+	 *
+	 * ```
+	 * mpSdk.Tour.stop()
+	 *   .then(function() {
+	 *     // Tour stop complete.
+	 *   })
+	 *   .catch(function(error) {
+	 *     // Tour stop error.
+	 *   });
+	 * ```
+	 *
+	 * @embed
+	 * @bundle
+	 */
+	stop(): Promise<void>;
+	/**
+	 * This function moves the camera to a specific snapshot in the tour.
+	 *
+	 * ```
+	 * const myStep = 2;
+	 * mpSdk.Tour.step(myStep)
+	 *   .then(function() {
+	 *     //Tour step complete.
+	 *   })
+	 *   .catch(function(error) {
+	 *     // Tour step error.
+	 *   });
+	 * ```
+	 *
+	 * @embed
+	 * @bundle
+	 */
+	step(index: number): Promise<void>;
+	/**
+	 * This function moves the camera to the next snapshot in the tour.
+	 *
+	 * ```
+	 * mpSdk.Tour.next()
+	 *   .then(function() {
+	 *     // Tour next complete.
+	 *   })
+	 *   .catch(function(error) {
+	 *     // Tour next error.
+	 *   });
+	 * ```
+	 *
+	 * @embed
+	 * @bundle
+	 */
+	next(): Promise<void>;
+	/**
+	 * This function moves the camera to the previous snapshot in the tour.
+	 *
+	 * ```
+	 * mpSdk.Tour.prev()
+	 *   .then(function() {
+	 *     // Tour prev complete.
+	 *   })
+	 *   .catch(function(error) {
+	 *     // Tour prev error.
+	 *   });
+	 * ```
+	 *
+	 * @embed
+	 * @bundle
+	 */
+	prev(): Promise<void>;
+	/**
+	 * This function returns an array of Snapshots.
+	 *
+	 * ```
+	 * mpSdk.Tour.getData()
+	 *   .then(function(snapshots) {
+	 *     // Tour getData complete.
+	 *     if(snapshots.length > 0){
+	 *       console.log('First snapshot sid: ' + snapshots[0].sid);
+	 *       console.log('First snapshot name: ' + snapshots[0].name);
+	 *       console.log('First snapshot position: ' + snapshots[0].position);
+	 *     }
+	 *   })
+	 *   .catch(function(error) {
+	 *     // Tour getData error.
+	 *   });
+	 * ```
+	 *
+	 * @embed
+	 * @bundle
+	 */
+	getData(): Promise<Tour.Snapshot[]>;
+	/**
+	 * The zero-indexed current Tour step.
+	 * The step will be null if no Tour is currently playing.
+	 *
+	 * ```
+	 * mpSdk.Tour.currentStep.subscribe(function (current) {
+	 *   // the step index has changed
+	 *   // 0 for the first step, 1 for the second, etc.
+	 *   console.log('Current step is ', current.step);
+	 * });
+	 * ```
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.68.12-7-g858688944a
+	 */
+	currentStep: IObservable<Tour.CurrentStepData>;
+	/**
+	 * An observable state of the current Tour. Returns a Tour.PlayState of
+	 * `INACTIVE` (no tour in progress), `ACTIVE` (tour in progress), or `STOP_SCHEDULED`
+	 * (tour in progress, but a stop has been queued by the user or automatically by the tour ending).
+	 *
+	 * ```
+	 * mpSdk.Tour.state.subscribe(function (state) {
+	 *   // the state has changed
+	 *   console.log('Current state is ', state.current);
+	 * });
+	 * ```
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.68.12-7-g858688944a
+	 */
+	state: IObservable<Tour.CurrentStateData>;
+	/**
+	 * An observable representing the current Tour's transition.
+	 *
+	 * `{ from: string | null, to: string | null }`.
+	 *
+	 * `from` can be `null` when transitioning from outside of a tour. `from` and `to` will both be `null` when
+	 * there is no active transition.
+	 *
+	 * ```
+	 * mpSdk.Tour.transition.subscribe(function (transition) {
+	 *   // the transition has changed
+	 *   console.log('Current transition is ', transition.from, transition.to);
+	 * });
+	 * ```
+	 *
+	 * @embed
+	 * @bundle
+	 * @introduced 3.1.68.12-7-g858688944a
+	 */
+	transition: IObservable<Tour.CurrentTransitionData>;
+}
+export declare namespace View {
+	interface View extends IObservable<View> {
+		/** the unique id of the View */
+		readonly id: string;
+		/** the human-readable name of the View */
+		readonly name: string;
+		/** whether this is the active View or not */
+		readonly active: boolean;
+		/**
+		 * An iterator over the set of Layers associated with this View
+		 *
+		 * ```typescript
+		 * for (const layer of view.layers) {
+		 *   console.log(`${view.id} has layer ${layer.id}`);
+		 * }
+		 * ```
+		 */
+		readonly layers: IterableIterator<Layer>;
+		/**
+		 * Set this View as the currently active one optionally, returning to the start location for the new View.
+		 *
+		 * Only one View can be active at a time.
+		 *
+		 * ```typescript
+		 * const view: View; // ... acquired through previous usage of `mpSdk.View.views`
+		 * await view.setActive(true); // set the active view and return to the start location
+		 * ```
+		 */
+		setActive(returnToStart?: boolean): Promise<void>;
+		/**
+		 * Add a Layer to this View
+		 *
+		 * ```typescript
+		 * view.addLayer(layer);
+		 * ```
+		 * @param layer
+		 */
+		addLayer(layer: Layer): Promise<void>;
+		/**
+		 * Remove a Layer from this View
+		 *
+		 * ```typescript
+		 * view.removeLayer(layer);
+		 * ```
+		 * @param layer
+		 */
+		removeLayer(layer: Layer): Promise<void>;
+		/**
+		 * Test if this View has a Layer associate with it
+		 *
+		 * ```typescript
+		 * if (view.hasLayer(layer)) {
+		 *   console.log(`${view.id} has layer ${layer.id}`);
+		 * }
+		 * ```
+		 * @param layer
+		 */
+		hasLayer(layer: Layer): boolean;
+	}
+	interface Layer extends IObservable<Layer> {
+		/** the unique id of the Layer */
+		id: string;
+		/** the human-readable name of the Layer */
+		name: string;
+		/**
+		 * Toggle this Layer's state to `active`.
+		 *
+		 * @param active Whether this Layer toggled on or off. If `active` is undefined, the state is flipped
+		 */
+		toggle(active?: boolean): Promise<void>;
+	}
+}
+export interface View {
+	/**
+	 * The currently active view
+	 *
+	 * ```typescript
+	 * mpSdk.View.current.subscribe((currentView) => {
+	 *   console.log('the currently active view is', currentView.name);
+	 * });
+	 * ```
+	 * @earlyaccess
+	 */
+	current: IObservable<View.View>;
+	/**
+	 * All views associated with the current space.
+	 *
+	 * ```typescript
+	 * mpSdk.View.views.subscribe({
+	 *   onAdded(index, view, collection) {
+	 *     console.log('a view with id', view.id, 'named', view.name);
+	 *   },
+	 *   onCollectionUpdated(collection) {
+	 *     console.log('all views', collection);
+	 *   },
+	 * });
+	 * ```
+	 * @earlyaccess
+	 */
+	views: IObservableMap<View.View>;
+	/**
+	 * All layers associated with the current space.
+	 *
+	 * Layers in inactive Views may not populate right away. Activating a View will trigger the Layers to populate.
+	 *
+	 * ```typescript
+	 * mpSdk.View.layers.subscribe({
+	 *   onAdded(index, layer, collection) {
+	 *     console.log('a layer with id', layer.id, 'named', layer.name);
+	 *   },
+	 *   onCollectionUpdated(collection) {
+	 *     console.log('all layers', collection);
+	 *   },
+	 * });
+	 * ```
+	 */
+	layers: IObservableMap<View.Layer>;
+	/**
+	 * Create a layer that can be later added to a View or Views
+	 *
+	 * ```typescript
+	 * const layer = await mpSdk.View.createLayer('my layer');
+	 * ```
+	 * @param name
+	 */
+	createLayer(name: string): Promise<View.Layer>;
+}
+interface Emitter {
+	/** Start listening for an event */
+	on: typeof on;
+	/** Stop listening for an event */
+	off: typeof off;
+}
+declare function off(event: any, callback: (...any: any[]) => void): Emitter;
+declare function on(event: App.Event.PHASE_CHANGE, callback: (app: App.Phase) => void): Emitter;
+declare function on(event: Camera.Event.MOVE, callback: (pose: Camera.Pose) => void): Emitter;
+declare function on(event: Floor.Event.CHANGE_START, callback: (to: number, from: number) => void): Emitter;
+declare function on(event: Floor.Event.CHANGE_END, callback: (floorIndex: number, floorName: string) => void): Emitter;
+declare function on(event: Label.Event.POSITION_UPDATED, callback: (labelData: Label.Label[]) => void): Emitter;
+declare function on(event: Mattertag.Event.HOVER, callback: (tagSid: string, hovering: boolean) => void): Emitter;
+declare function on(event: Mattertag.Event.CLICK, callback: (tagSid: string) => void): Emitter;
+declare function on(event: Mattertag.Event.LINK_OPEN, callback: (tagSid: string, url: string) => void): Emitter;
+declare function on(event: Mode.Event.CHANGE_START, callback: (oldMode: string, newMode: string) => void): Emitter;
+declare function on(event: Mode.Event.CHANGE_END, callback: (oldMode: string, newMode: string) => void): Emitter;
+declare function on(event: Model.Event.MODEL_LOADED, callback: (model: Model.ModelData) => void): Emitter;
+declare function on(event: Sweep.Event.ENTER, callback: (oldSweep: string, newSweep: string) => void): Emitter;
+declare function on(event: Sweep.Event.EXIT, callback: (fromSweep: string, toSweep: string | undefined) => void): Emitter;
+declare function on(event: Tour.Event.STARTED, callback: () => void): Emitter;
+declare function on(event: Tour.Event.STOPPED, callback: () => void): Emitter;
+declare function on(event: Tour.Event.ENDED, callback: () => void): Emitter;
+declare function on(event: Tour.Event.STEPPED, callback: (activeIndex: number) => void): Emitter;
+/**
+ * The entire MP Sdk returned from a successful call to `MP_SDK.connect` on the [[ShowcaseEmbedWindow]].
+ *
+ * ```typescript
+ * const sdk: CommonMpSdk = await window.MP_SDK.connect(...);
+ * ```
+ */
+export type CommonMpSdk = {
+	App: App;
+	Asset: Asset;
+	Camera: Camera;
+	Conversion: Conversion;
+	Floor: Floor;
+	Graph: Graph;
+	Label: Label;
+	Link: Link;
+	Mattertag: Mattertag;
+	Measurements: Measurements;
+	Mode: Mode;
+	Model: Model;
+	OAuth: OAuth;
+	Pointer: Pointer;
+	Renderer: Renderer;
+	Room: Room;
+	Sensor: Sensor;
+	Settings: Settings;
+	Sweep: Sweep;
+	Tag: Tag;
+	Test: Test;
+	Tour: Tour;
+	View: View;
+	on: typeof on;
+	off: typeof off;
+	disconnect: typeof disconnect;
+};
+export declare namespace CommonMpSdk {
+	export { Color, ConditionCallback, Dictionary, ICondition, IMapObserver, IObservable, IObservableMap, IObserver, ISubscription, ObserverCallback, Orientation, Rotation, Size, Vector2, Vector3, };
+	export { App, Asset, Camera, Conversion, Floor, Graph, Label, Link, Mattertag, Measurements, Mode, Model, OAuth, Pointer, Renderer, Room, Sensor, Settings, Sweep, Tag, Tour, View, };
+}
+/**
+ * When including the sdk script (`<script src='https://static.matterport.com/showcase-sdk/2.0.1-0-g64e7e88/sdk.js'>`) on your page,
+ * an [[MP_SDK]] will be attached to the window object.
+ *
+ * This type can be used to cast the window object to access the types available on the MP_SDK object.
+ *
+ * ```typescript
+ * const showcaseWindow = window as ShowcaseEmbedWindow;
+ * showcaseWindow.MP_SDK.connect( ... )
+ * ```
+ */
+export type ShowcaseEmbedWindow = Window & typeof globalThis & {
+	MP_SDK: MP_SDK;
+};
+/**
+ * The entrypoint for connecting to the SDK.
+ */
+export interface MP_SDK {
+	/**
+	 * Connect to the SDK and and create an [[MpSdk]] interface.
+	 *
+	 * ```typescript
+	 * const showcaseIframe = document.getElementById<HTMLIFrameElement>('showcase');
+	 * const showcaseWindow = window as ShowcaseEmbedWindow;
+	 * showcaseWindow.MP_SDK.connect(showcaseIframe, `${APPLICATION_KEY}, '');
+	 * ```
+	 * @param target
+	 * @param applicationKey
+	 * @param unused
+	 */
+	connect(target: HTMLIFrameElement, applicationKey: string, unused: ""): Promise<CommonMpSdk>;
+}
+
+export {
+	CommonMpSdk as MpSdk,
+};
+
+export {};

--- a/packages/embed-examples/examples/sensor-point-areas/index.ts
+++ b/packages/embed-examples/examples/sensor-point-areas/index.ts
@@ -1,14 +1,15 @@
 import { clearMesssage, connect, setMessage } from '../common';
+import type { MpSdk } from '../common/sdk';
 import '../common/main.css';
-import sourceDescs  from './sources.json';
+import sourceDescs from './sources.json';
 
 const main = async () => {
-  const sdk = await connect({
+  const sdk: MpSdk = await connect({
     urlParams: {
       qs: '1',
       play: '1',
       title: '0',
-    }
+    },
   });
 
   const textElement = document.getElementById('text') as HTMLDivElement;
@@ -17,7 +18,7 @@ const main = async () => {
   sensor.showDebug(true);
 
   sensor.readings.subscribe({
-    onCollectionUpdated: (sourceCollection: any) => {
+    onCollectionUpdated: (sourceCollection) => {
       const inRange: any[] = [];
       for (const [source, reading] of sourceCollection) {
         if (reading.inRange) {
@@ -29,25 +30,33 @@ const main = async () => {
           }
         }
 
-        console.log(
-          `sensor id: ${source.userData.id} inRange:${reading.inRange} inView:${reading.inView}`
-        );
+        console.log('sensor id', source.userData.id, 'inRange', reading.inRange, 'inView', reading.inView);
       }
 
       if (inRange.length > 0) {
         setMessage(textElement, inRange.toString());
-      }
-      else {
+      } else {
         clearMesssage(textElement);
       }
-    }
+    },
   });
 
   const sourcePromises: Promise<any>[] = [];
   for (const desc of sourceDescs) {
-    sourcePromises.push(sdk.Sensor.createSource(desc.type, desc.options));
+    switch (desc.type) {
+      case sdk.Sensor.SourceType.BOX:
+        sourcePromises.push(sdk.Sensor.createSource(<MpSdk.Sensor.SourceType.BOX>desc.type, desc.options));
+        break;
+      // Example of handling a sphere source and setting types correctly.
+      case sdk.Sensor.SourceType.SPHERE:
+        sourcePromises.push(sdk.Sensor.createSource(<MpSdk.Sensor.SourceType.SPHERE>desc.type, desc.options));
+        break;
+      // Example of handling a cylinder source and setting types correctly.
+      case sdk.Sensor.SourceType.CYLINDER:
+        sourcePromises.push(sdk.Sensor.createSource(<MpSdk.Sensor.SourceType.CYLINDER>desc.type, desc.options));
+        break;
+    }
   }
-
   const sources = await Promise.all(sourcePromises);
   sensor.addSource(...sources);
 };

--- a/packages/embed-examples/examples/sensor-sweep-control/index.ts
+++ b/packages/embed-examples/examples/sensor-sweep-control/index.ts
@@ -1,4 +1,5 @@
 import { clearMesssage, connect, setMessage } from '../common';
+import type { MpSdk } from '../common/sdk';
 import '../common/main.css';
 
 const initialSweepSid = '85e7bf413ca344da81e6ec42bcb4aaea';
@@ -6,41 +7,48 @@ const sourceSweepSid = '96fe9ff2682148878399aa2af5da847c';
 let inRangeCache: boolean = false;
 let currentSweepId: string = '';
 
-const checkDisableSweeps = (sdk: any, textElement: HTMLDivElement) => {
-  if (!inRangeCache){
+const checkDisableSweeps = (sdk: MpSdk, textElement: HTMLDivElement) => {
+  if (!inRangeCache) {
     if (currentSweepId === initialSweepSid) {
       const sweepSub = sdk.Sweep.data.subscribe({
         onCollectionUpdated: (sweeps: any) => {
-          const sids: string[] = Object.keys(sweeps)
-            .filter((sid: string) => sid !== initialSweepSid && sid !== sourceSweepSid);
+          const sids: string[] = Object.keys(sweeps).filter(
+            (sid: string) => sid !== initialSweepSid && sid !== sourceSweepSid
+          );
           sdk.Sweep.disable(...sids);
-
           sweepSub.cancel();
-          setMessage(textElement, 'Move towards the source to enable the rest of the sweeps');
+          setMessage(
+            textElement,
+            'Move towards the source to enable the rest of the sweeps'
+          );
         },
       });
-    }
-    else if (currentSweepId !== '') {
-      setMessage(textElement, 'Navigate to the start location to disable sweeps');
+    } else if (currentSweepId !== '') {
+      setMessage(
+        textElement,
+        'Navigate to the start location to disable sweeps'
+      );
     }
   }
 };
 
-const checkEnableSweeps = (sdk: any, textElement: HTMLDivElement) => {
+const checkEnableSweeps = (sdk: MpSdk, textElement: HTMLDivElement) => {
   if (inRangeCache) {
     const sweepSub = sdk.Sweep.data.subscribe({
-      onCollectionUpdated: (sweeps: any) => {
+      onCollectionUpdated: (sweeps) => {
         sdk.Sweep.enable(...Object.keys(sweeps));
         sweepSub.cancel();
-
-        setMessage(textElement, 'Navigate to the start location to disable sweeps');
+        setMessage(
+          textElement,
+          'Navigate to the start location to disable sweeps'
+        );
       },
     });
   }
 };
 
 const main = async () => {
-  const sdk = await connect({
+  const sdk: MpSdk = await connect({
     urlParams: {
       qs: '1',
       sr: '-3.04',
@@ -52,7 +60,7 @@ const main = async () => {
   const textElement = document.getElementById('text') as HTMLDivElement;
   clearMesssage(textElement);
 
-  sdk.Sweep.current.subscribe((sweep: any) => {
+  sdk.Sweep.current.subscribe((sweep) => {
     currentSweepId = sweep.sid;
     checkDisableSweeps(sdk, textElement);
     checkEnableSweeps(sdk, textElement);
@@ -61,29 +69,27 @@ const main = async () => {
   const sensor = await sdk.Sensor.createSensor(sdk.Sensor.SensorType.CAMERA);
   sensor.showDebug(true);
   const source = await sdk.Sensor.createSource(sdk.Sensor.SourceType.CYLINDER, {
-      basePoint: { x: -0.629, y: 1, z: 5.909 },
-      radius: 2.5,
-      height: 2.5,
-      userData: {
-        id: "Family Room",
-      },
+    basePoint: { x: -0.629, y: 1, z: 5.909 },
+    radius: 2.5,
+    height: 2.5,
+    userData: {
+      id: 'Family Room',
     },
-  );
+  });
 
   sensor.addSource(source);
   sensor.readings.subscribe({
-    onCollectionUpdated: (sourceCollection: any) => {
+    onCollectionUpdated: (sourceCollection) => {
       for (const [source, reading] of sourceCollection) {
-        console.log(`${source.userData.id}`);
+        console.log(source.userData.id);
         inRangeCache = reading.inRange;
         if (reading.inRange) {
           checkEnableSweeps(sdk, textElement);
-        }
-        else {
+        } else {
           checkDisableSweeps(sdk, textElement);
         }
-      }      
-    }
+      }
+    },
   });
 
   checkDisableSweeps(sdk, textElement);

--- a/packages/embed-examples/examples/sensor-tags-level-of-detail/index.ts
+++ b/packages/embed-examples/examples/sensor-tags-level-of-detail/index.ts
@@ -1,56 +1,58 @@
 import { clearMesssage, connect, setMessage } from '../common';
+import type { MpSdk } from '../common/sdk';
 import '../common/main.css';
 
-let lowDetailTag: string[]|null = null;
-let tags: string[]|null = null;
+let lowDetailTag: string[] | null = null;
+let tags: string[] | null = null;
 
-const createLowDetailTag = async (sdk: any) => {
-  const tagInfo = [{
-    label: 'Single tag',
-    description: `Move closer to see more.`,
-    anchorPosition: {
-      x: 0,
-      y: 1.3,
-      z: -0.227,
+const createLowDetailTag = async (sdk: MpSdk) => {
+  const tagInfo: MpSdk.Tag.Descriptor[] = [
+    {
+      label: 'Single tag',
+      description: 'Move closer to see more.',
+      anchorPosition: {
+        x: 0,
+        y: 1.3,
+        z: -0.227,
+      },
+      stemVector: {
+        x: 0,
+        y: 0.1,
+        z: 0,
+      },
+      color: {
+        r: 0.0,
+        g: 0.0,
+        b: 1.0,
+      },
     },
-    stemVector: {
-      x: 0,
-      y: 0.1,
-      z: 0,
-    },
-    color: {
-      r: 0.0,
-      g: 0.0,
-      b: 1.0,
-    },
-  }];
-
-  lowDetailTag = await sdk.Mattertag.add(tagInfo) as string[];
+  ];
+  lowDetailTag = await sdk.Tag.add(...tagInfo);
 };
 
-const removeLowDetailTag = (sdk: any) => {
+const removeLowDetailTag = (sdk: MpSdk) => {
   if (lowDetailTag !== null) {
-    sdk.Mattertag.remove(lowDetailTag);
+    sdk.Tag.remove(...lowDetailTag);
     lowDetailTag = null;
   }
 };
 
-const createTags = async (sdk: any) => {
-  const tagInfos = [];
+const createTags = async (sdk: MpSdk) => {
+  const tagInfos: MpSdk.Tag.Descriptor[] = [];
   const side = 1; // 1 meter
   const halfSide = side / 2;
-  const center = {x: 0.15, y: 1.3, z: -0.227 };
+  const center = { x: 0.15, y: 1.3, z: -0.227 };
   const tagPerSide = 4;
   const spacing = side / tagPerSide;
 
-  for (let i=0; i<tagPerSide; i++) {
-    for (let j=0; j<tagPerSide; j++) {
-      tagInfos.push({
+  for (let i = 0; i < tagPerSide; i++) {
+    for (let j = 0; j < tagPerSide; j++) {
+      const newTag: MpSdk.Tag.Descriptor = {
         label: `Tag ${i},${j}`,
-        description: ``,
+        description: '',
         anchorPosition: {
-          x: center.x - halfSide + (i * spacing),
-          y: center.y - halfSide + (j * spacing),
+          x: center.x - halfSide + i * spacing,
+          y: center.y - halfSide + j * spacing,
           z: center.z,
         },
         stemVector: {
@@ -63,22 +65,22 @@ const createTags = async (sdk: any) => {
           g: 0.0,
           b: 0.0,
         },
-      });
+      };
+      tagInfos.push(newTag);
     }
   }
-
-  tags = await sdk.Mattertag.add(tagInfos) as string[];
+  tags = (await sdk.Tag.add(...tagInfos));
 };
 
-const removeTags = (sdk: any) => {
+const removeTags = (sdk: MpSdk) => {
   if (tags !== null) {
-    sdk.Mattertag.remove(tags);
+    sdk.Tag.remove(...tags);
     tags = null;
   }
 };
 
 const main = async () => {
-  const sdk = await connect({
+  const sdk: MpSdk = await connect({
     urlParams: {
       qs: '1',
       sr: '-.18,.03',
@@ -95,14 +97,14 @@ const main = async () => {
     origin: { x: -0.101, y: 1, z: -0.99 },
     radius: 5,
     userData: {
-      id: "Window Area Far",
+      id: 'Window Area Far',
     },
   });
   const source1 = await sdk.Sensor.createSource(sdk.Sensor.SourceType.SPHERE, {
     origin: { x: -0.101, y: 0.6, z: -0.99 },
     radius: 2,
     userData: {
-      id: "Window Area Near",
+      id: 'Window Area Near',
     },
   });
 
@@ -121,25 +123,23 @@ const main = async () => {
           }
         }
       }
-      
+
       if (inRange.length === 1) {
         // far range
         setMessage(textElement, 'Single tag representing a cluster of tags');
         removeTags(sdk);
         createLowDetailTag(sdk);
-      }
-      else if (inRange.length === 2) {
+      } else if (inRange.length === 2) {
         // near range
         setMessage(textElement, 'A cluster of tags');
         removeLowDetailTag(sdk);
         createTags(sdk);
-      }
-      else {
+      } else {
         clearMesssage(textElement);
         removeTags(sdk);
         removeLowDetailTag(sdk);
       }
-    }
+    },
   });
 };
 

--- a/packages/embed-examples/examples/sensor-tags-per-sweep/index.ts
+++ b/packages/embed-examples/examples/sensor-tags-per-sweep/index.ts
@@ -1,16 +1,17 @@
 import { clearMesssage, connect, setMessage } from '../common';
+import type { MpSdk } from '../common/sdk';
 import '../common/main.css';
 
-let tags: string[]|null = null;
+let tags: string[] | null = null;
 let sub: any = null;
 
-const addTags = async (sdk: any) => {
+const addTags = async (sdk: MpSdk) => {
   if (tags) {
     return;
   }
 
   sub = sdk.Sweep.data.subscribe({
-    onCollectionUpdated: async (collection: {[key: string]: any}) => {
+    onCollectionUpdated: async (collection: { [key: string]: any }) => {
       const tagInfos: any[] = Object.keys(collection).map((key: string) => {
         const sweep = collection[key];
         return {
@@ -31,9 +32,9 @@ const addTags = async (sdk: any) => {
             g: 0.0,
             b: 1.0,
           },
-        }
+        };
       });
-      tags = await sdk.Mattertag.add(tagInfos) as string[];
+      tags = (await sdk.Tag.add(...tagInfos)) as string[];
       sub.cancel();
     },
   });
@@ -41,13 +42,13 @@ const addTags = async (sdk: any) => {
 
 const removeTags = async (sdk: any) => {
   if (tags !== null) {
-    sdk.Mattertag.remove(tags);
+    sdk.Tag.remove(tags);
     tags = null;
   }
-}
+};
 
 const main = async () => {
-  const sdk = await connect({
+  const sdk: MpSdk = await connect({
     urlParams: {
       qs: '1',
       play: '1',
@@ -62,7 +63,7 @@ const main = async () => {
     origin: { x: -0.629, y: 1, z: 5.909 },
     radius: 2.5,
     userData: {
-      id: "Displaying a tag over every sweep",
+      id: 'Displaying a tag over every sweep',
     },
   });
 
@@ -85,12 +86,11 @@ const main = async () => {
       if (inRange.length > 0) {
         setMessage(textElement, inRange.toString());
         addTags(sdk);
-      }
-      else {
+      } else {
         clearMesssage(textElement);
         removeTags(sdk);
       }
-    }
+    },
   });
 };
 

--- a/packages/embed-examples/index.ejs
+++ b/packages/embed-examples/index.ejs
@@ -29,9 +29,7 @@
     }
   </style>
   <title><%= title %></title>
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="preload" as="style">
-  <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:400,700&display=swap" rel="preload" as="style">
-  <script src="https://static.matterport.com/showcase-sdk/2.0.1-0-g64e7e88/sdk.js"></script>
+  <script src='https://static.matterport.com/showcase-sdk/latest.js'></script>
 </head>
 
 <body>

--- a/packages/inspector/src/CloseupView.ts
+++ b/packages/inspector/src/CloseupView.ts
@@ -1,5 +1,5 @@
 import { SceneComponent, ComponentOutput, ISceneNode } from '@mp/common';
-import { Camera, Object3D, Vector3, Quaternion, Matrix4 } from 'three';
+import { PerspectiveCamera, Object3D, Vector3, Quaternion, Matrix4 } from 'three';
 import TWEEN from '@tweenjs/tween.js';
 
 type Position = {
@@ -25,7 +25,7 @@ type Inputs = {
 };
 
 type Outputs = {
-  camera: null | Camera;
+  camera: null | PerspectiveCamera;
 } & ComponentOutput;
 
 type Events = {
@@ -34,7 +34,7 @@ type Events = {
 };
 
 class CloseupView extends SceneComponent {
-  private camera: Camera;
+  private camera: PerspectiveCamera;
   private time = 0;
   private position: Position = {
     x: 0,
@@ -55,7 +55,7 @@ class CloseupView extends SceneComponent {
   };
 
   outputs = {
-    camera: null as null | Camera,
+    camera: null as null | PerspectiveCamera,
   } as Outputs;
 
   events = {
@@ -136,7 +136,7 @@ class CloseupView extends SceneComponent {
       })
       .start(0);
 
-    const dummy = new THREE.Camera();
+    const dummy = new THREE.PerspectiveCamera();
     const qStart = new THREE.Quaternion();
     const qEnd = new THREE.Quaternion();
 
@@ -144,9 +144,9 @@ class CloseupView extends SceneComponent {
     this.quaternionTween = new TWEEN.Tween(this.quaternionTime)
       .to({ t: 1.0 }, this.inputs.duration * 1000)
       .easing(TWEEN.Easing.Cubic.InOut)
-      .onStart(() =>  {
-        dummy.position.copy( this.camera.position );
-        dummy.lookAt( new Vector3().set(target.x, target.y, target.z) );
+      .onStart(() => {
+        dummy.position.copy(this.camera.position);
+        dummy.lookAt(new Vector3().set(target.x, target.y, target.z));
         qStart.copy(this.camera.quaternion);
         qEnd.copy(q);
       })
@@ -163,7 +163,7 @@ class CloseupView extends SceneComponent {
 
   onEvent(eventType: string, eventData: unknown) {
     const data = eventData as any;
-    switch(eventType) {
+    switch (eventType) {
       case Event.OnAccessGranted:
         this.setupCameraAnimation(data.pose);
         break;

--- a/packages/inspector/src/Grid.ts
+++ b/packages/inspector/src/Grid.ts
@@ -43,33 +43,33 @@ class Grid extends SceneComponent {
     }
 
     const obj3D = new THREE.Object3D();
-    const grid = new GridHelper( 200, 200, 0xffffff, 0x777777 );
-		grid.material.opacity = 0.3;
-		grid.material.transparent = true;
+    const grid = new GridHelper(200, 200, 0xffffff, 0x777777);
+    grid.material.opacity = 0.3;
+    grid.material.transparent = true;
     obj3D.add(grid);
 
     var uniforms = {
-      "topColor": { value: new THREE.Color( 0x001144 ) },
-      "bottomColor": { value: new THREE.Color( 0xffffff ) },
+      "topColor": { value: new THREE.Color(0x001144) },
+      "bottomColor": { value: new THREE.Color(0xffffff) },
       "offset": { value: 2 },
       "exponent": { value: 0.4 }
     };
 
-    var skyGeo = new THREE.SphereBufferGeometry(100, 32, 15 );
-    var skyMat = new THREE.ShaderMaterial( {
+    var skyGeo = new THREE.SphereGeometry(100, 32, 15);
+    var skyMat = new THREE.ShaderMaterial({
       uniforms: uniforms,
       vertexShader: gradientVertexShader(),
       fragmentShader: gradientFragmentShader(),
       side: THREE.BackSide
-    } );
-    var sky = new THREE.Mesh( skyGeo, skyMat );
+    });
+    var sky = new THREE.Mesh(skyGeo, skyMat);
     obj3D.add(sky);
 
-    var geometry = new THREE.SphereGeometry( 95, 32, 15, 0, Math.PI, 0, Math.PI );
-    var material = new THREE.MeshBasicMaterial( {color: 0x000000, side: THREE.DoubleSide} );
-    var plane = new THREE.Mesh( geometry, material );
+    var geometry = new THREE.SphereGeometry(95, 32, 15, 0, Math.PI, 0, Math.PI);
+    var material = new THREE.MeshBasicMaterial({ color: 0x000000, side: THREE.DoubleSide });
+    var plane = new THREE.Mesh(geometry, material);
     plane.rotateX(Math.PI / 2);
-    plane.position.set(0,0,0);
+    plane.position.set(0, 0, 0);
     obj3D.add(plane);
 
     this.outputs.objectRoot = obj3D;

--- a/packages/inspector/src/Scene.ts
+++ b/packages/inspector/src/Scene.ts
@@ -39,7 +39,7 @@ class Scene implements IScene {
   public get cameraPose() {
     return this.cameraPoseSubject;
   }
-  
+
   private async setup(sdk: any) {
     sdk.Camera.pose.subscribe((pose: any) => {
       this.cameraPoseSubject.next({
@@ -64,7 +64,7 @@ class Scene implements IScene {
     ]);
     this.sensor = await sdk.Sensor.createSensor(sdk.Sensor.SensorType.CAMERA);
     this.sensor.showDebug(true);
-  
+
     const node = await sdk.Scene.createNode();
     this.widget = node.addComponent('mp.transformControls');
     node.start();
@@ -113,7 +113,8 @@ class Scene implements IScene {
   }
 
   public async deserialize(serialized: string) {
-    const nodes: ISceneNode[] = await this.sdk.sdk.Scene.deserialize(serialized);
+    const sceneObject = await this.sdk.sdk.Scene.deserialize(serialized);
+    const nodes: ISceneNode[] = [...sceneObject.nodeIterator()];
 
     const added: ISceneNode[] = [];
     for (const node of nodes) {

--- a/packages/inspector/src/SplineCamera.ts
+++ b/packages/inspector/src/SplineCamera.ts
@@ -1,5 +1,5 @@
 import { SceneComponent, ComponentOutput } from '@mp/common';
-import { TubeBufferGeometry, Vector3, Camera, Mesh } from 'three';
+import { TubeGeometry, Vector3, Camera, Mesh } from 'three';
 
 export const DoneEvent = 'done';
 
@@ -9,7 +9,7 @@ type Outputs = {
 } & ComponentOutput;
 
 class SplineCamera extends SceneComponent {
-  private tubeGeometry: TubeBufferGeometry;
+  private tubeGeometry: TubeGeometry;
   private position: Vector3 = new Vector3();
   private binormal: Vector3 = new Vector3();
   private direction: Vector3 = new Vector3();
@@ -31,39 +31,39 @@ class SplineCamera extends SceneComponent {
 
     this.camera = new this.context.three.PerspectiveCamera();
     const points: THREE.Vector3[] = [
-      new THREE.Vector3(  -0.09, 3.83, -7.53 ),
-      new THREE.Vector3( 0.9, 1.11, -1.61 ),
-      new THREE.Vector3( -1.88, 1.11, 3.05 ),
-      new THREE.Vector3( -1.57, 1.11, 7.07 ),
-      new THREE.Vector3( 1.0, 3.89, 8.63 ),
-      new THREE.Vector3( 1.78, 4.62, 5.89 ),
-      new THREE.Vector3( 1.8, 4.62, 3.86 ),
-      new THREE.Vector3( -0.5, 4.69, 3.86 ),
-      new THREE.Vector3( -0.2, 4.69, 0.20 ),
+      new THREE.Vector3(-0.09, 3.83, -7.53),
+      new THREE.Vector3(0.9, 1.11, -1.61),
+      new THREE.Vector3(-1.88, 1.11, 3.05),
+      new THREE.Vector3(-1.57, 1.11, 7.07),
+      new THREE.Vector3(1.0, 3.89, 8.63),
+      new THREE.Vector3(1.78, 4.62, 5.89),
+      new THREE.Vector3(1.8, 4.62, 3.86),
+      new THREE.Vector3(-0.5, 4.69, 3.86),
+      new THREE.Vector3(-0.2, 4.69, 0.20),
     ]
 
     const pipeSpline = new THREE.CatmullRomCurve3(points);
 
-    this.tubeGeometry = new THREE.TubeBufferGeometry( pipeSpline, 100, 0.1, 5, true );
-    const material = new THREE.MeshLambertMaterial( { color: 0x008800, blending: THREE.AdditiveBlending, transparent: true, opacity: 0.3 } );
-    const wireframeMaterial = new THREE.MeshBasicMaterial( { color: 0x004400, opacity: 0.4, wireframe: true, transparent: true } );
-    const mesh = new THREE.Mesh( this.tubeGeometry, material );
-    const wireframe = new THREE.Mesh( this.tubeGeometry, wireframeMaterial );
-    mesh.add( wireframe );
-    mesh.scale.set( scale, scale, scale );
-    
+    this.tubeGeometry = new THREE.TubeGeometry(pipeSpline, 100, 0.1, 5, true);
+    const material = new THREE.MeshLambertMaterial({ color: 0x008800, blending: THREE.AdditiveBlending, transparent: true, opacity: 0.3 });
+    const wireframeMaterial = new THREE.MeshBasicMaterial({ color: 0x004400, opacity: 0.4, wireframe: true, transparent: true });
+    const mesh = new THREE.Mesh(this.tubeGeometry, material);
+    const wireframe = new THREE.Mesh(this.tubeGeometry, wireframeMaterial);
+    mesh.add(wireframe);
+    mesh.scale.set(scale, scale, scale);
+
     this.outputs.objectRoot = mesh;
     this.outputs.camera = this.camera;
     this.startTime = Date.now();
 
     for (const point of points) {
-      const geometry = new THREE.SphereGeometry( 0.05, 16, 16 );
-      const material = new THREE.MeshBasicMaterial( {color: 0x0000bb } );
-      const sphere = new THREE.Mesh( geometry, material );
+      const geometry = new THREE.SphereGeometry(0.05, 16, 16);
+      const material = new THREE.MeshBasicMaterial({ color: 0x0000bb });
+      const sphere = new THREE.Mesh(geometry, material);
       sphere.position.copy(point);
       this.spheres.push(sphere);
       mesh.add(sphere);
-      
+
       this.disposables.push(geometry);
       this.disposables.push(material);
     }
@@ -76,34 +76,34 @@ class SplineCamera extends SceneComponent {
   onTick() {
     const time = Date.now() - this.startTime;
     const looptime = 20 * 1000;
-    const t = ( time % looptime ) / looptime;
+    const t = (time % looptime) / looptime;
 
-    this.tubeGeometry.parameters.path.getPointAt( t, this.position);
+    this.tubeGeometry.parameters.path.getPointAt(t, this.position);
     this.position.multiplyScalar(scale);
 
     const segments = this.tubeGeometry.tangents.length;
     const pickt = t * segments;
-    var pick = Math.floor( pickt );
-    var pickNext = ( pick + 1 ) % segments;
+    var pick = Math.floor(pickt);
+    var pickNext = (pick + 1) % segments;
 
-    this.binormal.subVectors( this.tubeGeometry.binormals[ pickNext ], this.tubeGeometry.binormals[ pick ] );
-    this.binormal.multiplyScalar( pickt - pick ).add( this.tubeGeometry.binormals[ pick ] );
+    this.binormal.subVectors(this.tubeGeometry.binormals[pickNext], this.tubeGeometry.binormals[pick]);
+    this.binormal.multiplyScalar(pickt - pick).add(this.tubeGeometry.binormals[pick]);
 
-    this.direction.copy(this.tubeGeometry.parameters.path.getTangentAt( t ));
+    this.direction.copy(this.tubeGeometry.parameters.path.getTangentAt(t));
     var offset = 0;
 
-    this.normal.copy( this.binormal ).cross( this.direction ).negate();
-    this.normal.set(0,1,0);
+    this.normal.copy(this.binormal).cross(this.direction).negate();
+    this.normal.set(0, 1, 0);
 
-    this.position.add( this.normal.clone().multiplyScalar( offset ) );
+    this.position.add(this.normal.clone().multiplyScalar(offset));
 
     this.camera.position.copy(this.position);
 
-    this.tubeGeometry.parameters.path.getPointAt( ( t + 2 / this.tubeGeometry.parameters.path.getLength() ) % 1, this.lookAt );
-		this.lookAt.multiplyScalar( scale );
+    this.tubeGeometry.parameters.path.getPointAt((t + 2 / this.tubeGeometry.parameters.path.getLength()) % 1, this.lookAt);
+    this.lookAt.multiplyScalar(scale);
 
-		this.camera.matrix.lookAt( this.camera.position, this.lookAt, this.normal );
-    this.camera.quaternion.setFromRotationMatrix( this.camera.matrix );
+    this.camera.matrix.lookAt(this.camera.position, this.lookAt, this.normal);
+    this.camera.quaternion.setFromRotationMatrix(this.camera.matrix);
 
     if (time > 20 * 1000) {
       this.notify(DoneEvent);

--- a/packages/inspector/src/components/Main.tsx
+++ b/packages/inspector/src/components/Main.tsx
@@ -184,7 +184,9 @@ export class MainView extends Component<Props, State> {
   }
 
   private transformSelected(selection: Selection) {
-    this.context.scene.widget.inputs.mode = selection;
+    if (selection !== null) {
+      this.context.scene.widget.inputs.mode = selection;
+    }
   }
 
   private async dropped(objects: string) {
@@ -242,7 +244,7 @@ export class MainView extends Component<Props, State> {
           if (this.context.scene.widget) {
             this.context.scene.widget.inputs.selection = null;
           }
-          
+
           if (this.context.scene.cameraInput) {
             this.context.scene.cameraInput.inputs.focus = null;
           }
@@ -314,7 +316,7 @@ export class MainView extends Component<Props, State> {
             </ToolbarDiv>
             <ContainerDiv>
               <FrameView src={src}></FrameView>
-                
+
                 <TabPanelDiv>
                   <Tabs value={this.state.tabIndex} onChange={this.onTabChanged} aria-label="simple tabs example" variant='standard'>
                     <Tab label="Nodes" value={0} sx={styles.tab}/>

--- a/packages/inspector/src/components/SceneView.tsx
+++ b/packages/inspector/src/components/SceneView.tsx
@@ -70,7 +70,7 @@ export class SceneView extends Component<Props, State> {
     this.setState({
       selected: newNodeId,
     });
-    
+
     if (newNodeId === nodeId) {
       this.props.onSingleClick(item);
     }
@@ -100,9 +100,9 @@ export class SceneView extends Component<Props, State> {
             nodeId={`${nodeId}`}
             key={`${nodeId}`}
             label={object.name}
-            onKeyDown={(e) => this.onKeyDown(e, object)}
-            onClick={(e) => this.onClick(e, `${nodeId}`, object)}
-            onDoubleClick={(e) => this.onDoubleClick(e, `${nodeId}`, object)}
+            onKeyDown={(e: React.KeyboardEvent<HTMLElement>) => this.onKeyDown(e, object)}
+            onClick={(e: React.MouseEvent<HTMLElement>) => this.onClick(e, `${nodeId}`, object)}
+            onDoubleClick={(e: React.MouseEvent<HTMLElement>) => this.onDoubleClick(e, `${nodeId}`, object)}
           ></TreeItem>
         );
       });

--- a/packages/inspector/src/components/TransformToolbar.tsx
+++ b/packages/inspector/src/components/TransformToolbar.tsx
@@ -51,7 +51,7 @@ export class TransformToolbar extends Component<Props, State> {
     this.setState({
       selection,
     });
-    
+
     if (this.props.selectionChanged) {
       this.props.selectionChanged(selection);
     }
@@ -70,18 +70,18 @@ export class TransformToolbar extends Component<Props, State> {
                 aria-label="text alignment"
               >
                 <ToggleButton value={Selection.Translate} aria-label="left aligned">
-                <img src={`${cdnUrl}/textures/move.jpg`} alt="Kitten" height="40" width="40"/>
+                <img src={`${cdnUrl}/textures/move.jpg`} alt="Move" height="40" width="40"/>
                 </ToggleButton>
                 <ToggleButton value={Selection.Rotate} aria-label="centered">
-                <img src={`${cdnUrl}/textures/rotate.jpg`} alt="Kitten" height="40" width="40"/>
+                <img src={`${cdnUrl}/textures/rotate.jpg`} alt="Rotate" height="40" width="40"/>
                 </ToggleButton>
                 <ToggleButton value={Selection.Scale} aria-label="right aligned">
-                  <img src={`${cdnUrl}/textures/scale.jpg`} alt="Kitten" height="40" width="40"/>
+                  <img src={`${cdnUrl}/textures/scale.jpg`} alt="Scale" height="40" width="40"/>
                 </ToggleButton>
               </ToggleButtonGroup>
             </div>
           </Grid>
-          
+
         </Grid>
       </ControlsDiv>
     );

--- a/packages/training-tags-demo/README.md
+++ b/packages/training-tags-demo/README.md
@@ -1,0 +1,3 @@
+# sdk-training-tags-demo
+
+A demo example of using Mattertags in training applications

--- a/packages/training-tags-demo/app.ts
+++ b/packages/training-tags-demo/app.ts
@@ -1,0 +1,325 @@
+import { sdkKey } from '@mp/common';
+import { MpSdk } from '../bundle/sdk';
+
+import './style.css';
+
+declare global {
+  interface Window {
+    MP_SDK: {
+      connect(iframe: HTMLIFrameElement, key: string, unused: ''): Promise<MpSdk>;
+    }
+  }
+}
+
+const sid = `iL4RdJqi2yK`;
+const params = `&hl=2&play=1&qs=1&applicationKey=${sdkKey}`;
+
+type Question = {
+  title: string;
+  description: string | null;
+  answer: string;
+  choices: string[];
+  tag: Partial<MpSdk.Tag.TagData>;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  let iframe = document.querySelector<HTMLIFrameElement>('.showcase');
+  iframe.setAttribute('src', `https://my.matterport.com/show/?m=${sid}${params}`);
+  iframe.addEventListener('load', () => showcaseLoader(iframe));
+});
+
+function createTag(question: Question, mpSdk: MpSdk) {
+  mpSdk.Tag.add(question.tag as MpSdk.Tag.Descriptor)
+    .then(sid => {
+      question.tag.id = sid[0];
+    })
+    .catch(console.error);
+}
+
+function createQuestionElement(question: Question) {
+  let choices = question.choices;
+
+  // Create question container
+  let questionElement = document.createElement('div');
+  questionElement.setAttribute('class', 'question');
+  questionElement.classList.add('unselected');
+
+  // Create title
+  let title = document.createElement('h3');
+  title.setAttribute('class', 'question_title')
+  title.innerText = question.title;
+  questionElement.insertAdjacentElement('beforeend', title);
+
+  // Create form wrapper
+  let form = document.createElement('form');
+  questionElement.insertAdjacentElement('beforeend', form);
+
+  // Create choice wrapper
+  let choice_list = document.createElement('ul');
+  choice_list.setAttribute('class', 'choices');
+  form.insertAdjacentElement('beforeend', choice_list);
+
+  // Create choices
+  choices.forEach((choice, i) => {
+    let item = document.createElement('li');
+    item.setAttribute('class', 'choice');
+
+    // radio button
+    let btn = document.createElement('input')
+    btn.setAttribute('type', 'radio');
+    btn.setAttribute('id', String(i))
+    btn.setAttribute('name', 'choice');
+    btn.setAttribute('value', String(i));
+
+    // label
+    let label = document.createElement('label');
+    label.setAttribute('for', `${i}`);
+    label.innerText = choice
+
+    item.insertAdjacentElement('beforeend', btn)
+    item.insertAdjacentElement('beforeend', label)
+    choice_list.insertAdjacentElement('beforeend', item)
+  });
+
+  // Go To button
+  let goToBtn = document.createElement('button');
+  goToBtn.setAttribute('class', 'goto_button');
+  goToBtn.innerText = 'Go to Tag'
+  questionElement.insertAdjacentElement('beforeend', goToBtn);
+
+  return questionElement
+}
+
+function updateTagColor(tag: Partial<MpSdk.Tag.TagData>, newColor: MpSdk.Color, mpSdk: MpSdk) {
+  if (!tag) return;
+  if (tag.hasOwnProperty('color')) {
+    tag.color = newColor;
+  }
+  mpSdk.Tag.editColor(tag.id, newColor)
+    .catch(console.error);
+}
+
+function updateTagDescription(tag: Partial<MpSdk.Tag.TagData>, newDescription: string, mpSdk: MpSdk) {
+  if (!tag) return;
+  if (tag.hasOwnProperty('description')) {
+    tag.description = newDescription;
+  }
+  mpSdk.Tag.editBillboard(tag.id, { description: newDescription })
+    .catch(console.error);
+}
+
+function giveQuestionListeners(question: Question, questionElement: HTMLElement, mpSdk: MpSdk) {
+
+  questionElement.addEventListener('click', () => {
+    let q = document.querySelector('.selected');
+    if (q) {
+      q.classList.replace('selected', 'unselected');
+    }
+    questionElement.classList.replace('unselected', 'selected');
+  });
+
+  let choices = questionElement.querySelectorAll('.choice');
+
+  choices.forEach((li: HTMLLIElement) => {
+    let inp = li.children[0] as HTMLInputElement;
+    inp.addEventListener('change', newVal => {
+      let ans = document.createElement('h4');
+      const id = (newVal.target as HTMLElement).getAttribute('id');
+      if (id === question.answer) {
+        ans.setAttribute('style', 'color: rgb(9, 179, 9); font-style: italic;');
+        ans.innerText = 'Correct';
+        updateTagColor(question.tag, { r: 0, g: 1, b: 0 }, mpSdk);
+      } else {
+        ans.setAttribute('style', 'color: rgb(179, 9, 9); font-style: italic;');
+        ans.innerText = 'Incorrect';
+        updateTagColor(question.tag, { r: 1, g: 0, b: 0 }, mpSdk);
+      }
+      updateTagDescription(question.tag, ans.innerText, mpSdk);
+      if (questionElement.children[0].tagName === 'H4') {
+        questionElement.removeChild(questionElement.children[0]);
+      }
+      questionElement.insertAdjacentElement('afterbegin', ans);
+    });
+  });
+
+  let goto = questionElement.querySelector('.goto_button');
+  goto.addEventListener('click', () => {
+    // Legacy Method with no equivalent in Tag Namespace
+    mpSdk.Mattertag.navigateToTag(question.tag.id, mpSdk.Mattertag.Transition.FADEOUT)
+      .catch(console.error);
+  });
+
+}
+
+function loadQuestions(mpSdk: MpSdk) {
+
+  let questionsEle = document.querySelector('.questions');
+
+  // Can also load questions from file or database
+  let questions: Question[] = [
+    {
+      'title': 'What brand is the fridge?',
+      'description': null,
+      'answer': '1',
+      'choices': ['GE', 'Sub-Zero', 'Kenmore', 'LG'],
+      'tag': {
+        'id': 'aUMYG5cfYMm',
+        'label': 'What brand is the fridge?',
+        'description': '',
+        'anchorPosition': {
+          'x': 5.314893167599408,
+          'y': -0.1567343140995423,
+          'z': 10.455523925678921
+        },
+        'color': {
+          'r': 0,
+          'g': 0,
+          'b': 1
+        },
+        'stemVector': {
+          'x': 0,
+          'y': 0.2,
+          'z': 0
+        },
+        'stemVisible': true
+      }
+    },
+    {
+      'title': 'How wide is the TV?',
+      'description': null,
+      'answer': '2',
+      'choices': ["10'", "3'2\"", "6'5\"", "1'"],
+      'tag': {
+        'id': 'hDZVtcsGd5t',
+        'label': 'How wide is the TV?',
+        'description': '',
+        'anchorPosition': {
+          'x': 6.808068364327917,
+          'y': -0.7514079923325638,
+          'z': 1.2463780759085934
+        },
+        'color': {
+          'r': 0,
+          'g': 0,
+          'b': 1
+        },
+        'stemVector': {
+          'x': 0,
+          'y': 0.2,
+          'z': 0
+        },
+        'stemVisible': true
+      }
+    },
+    {
+      'title': 'What is the recommended procedure with a table during an earthquake?',
+      'description': null,
+      'answer': '2',
+      'choices': ['Get on top of the table', 'Move the table outside', 'Get under the table', 'Get under a chandelier'],
+      'tag': {
+        'id': 'ehDVQ3HF1al',
+        'label': 'What is the recommended procedure with a table during an earthquake?',
+        'description': '',
+        'anchorPosition': {
+          'x': 0.4731829189866753,
+          'y': -0.8998377744732301,
+          'z': 5.968713694470143
+        },
+        'color': {
+          'r': 0,
+          'g': 0,
+          'b': 1
+        },
+        'stemVector': {
+          'x': 0,
+          'y': 0.2,
+          'z': 0
+        },
+        'stemVisible': true
+      }
+    },
+    {
+      'title': 'Who should you call in an emergency?',
+      'description': null,
+      'answer': '0',
+      'choices': ['911', 'Ghostbusters', 'Grandma', 'Matterport Customer Support'],
+      'tag': {
+        'id': 'kMF3VzNIslo',
+        'label': 'Who should you call in an emergency?',
+        'description': '',
+        'anchorPosition': {
+          'x': 5.015846850857473,
+          'y': -0.8528928246952776,
+          'z': 7.197700847992113
+        },
+        'color': {
+          'r': 0,
+          'g': 0,
+          'b': 1
+        },
+        'stemVector': {
+          'x': 0,
+          'y': 0.2,
+          'z': 0
+        },
+        'stemVisible': true
+      }
+    },
+    {
+      'title': 'What color is this chair?',
+      'description': null,
+      'answer': '0',
+      'choices': ['Red', 'Blue', 'Yellow', 'Green'],
+      'tag': {
+        'id': 'DsYfDW00lSB',
+        'label': 'What color is this chair?',
+        'description': '',
+        'anchorPosition': {
+          'x': 5.8739787740590685,
+          'y': 2.1396123213050684,
+          'z': 8.299051556795263
+        },
+        'color': {
+          'r': 0,
+          'g': 0,
+          'b': 1
+        },
+        'stemVector': {
+          'x': 0,
+          'y': 0.2,
+          'z': 0
+        },
+        'stemVisible': true
+      }
+    }
+  ];
+
+  questions.forEach(question => {
+    createTag(question, mpSdk);
+    let questionEle = createQuestionElement(question);
+    questionsEle.insertAdjacentElement('beforeend', questionEle);
+    giveQuestionListeners(question, questionEle, mpSdk);
+  });
+}
+
+function showcaseLoader(iframe: HTMLIFrameElement) {
+  try {
+    window.MP_SDK.connect(iframe, sdkKey, '')
+      .then(loadedShowcaseHandler)
+      .catch(console.error);
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+function loadedShowcaseHandler(mpSdk: MpSdk) {
+  const sub = mpSdk.Tag.data.subscribe({
+    onCollectionUpdated(collection) {
+      let allTagSids = Object.keys(collection);
+      mpSdk.Tag.remove(...allTagSids);
+      // Load questions and tags
+      loadQuestions(mpSdk);
+      sub.cancel();
+    },
+  });
+}

--- a/packages/training-tags-demo/index.html
+++ b/packages/training-tags-demo/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Mattertag Training Example</title>
+    <script src="https://static.matterport.com/showcase-sdk/latest.js"></script>
+  </head>
+  <body>
+    <div class="container">
+
+      <div class="showcase_wrapper">
+        <iframe class="showcase" frameborder="0" allowfullscreen></iframe>
+      </div>
+      <div class="questions"></div>
+    </div>
+  </body>
+</html>

--- a/packages/training-tags-demo/package.json
+++ b/packages/training-tags-demo/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "training-tags-demo",
+  "version": "1.0.0",
+  "main": "./app.ts",
+  "dependencies": {
+    "@mp/common": "^1.0.0"
+  },
+  "scripts": {
+    "develop": "webpack-dev-server",
+    "build-prod": "webpack --mode=production",
+    "build-dev": "webpack --mode=development"
+  }
+}

--- a/packages/training-tags-demo/style.css
+++ b/packages/training-tags-demo/style.css
@@ -1,0 +1,105 @@
+* {
+  margin: 0;
+  padding: 0;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+body{
+  background-color: #FFFFFF;
+}
+
+.container {
+  margin: 15px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  color: #222222;
+  max-height: 98vh;
+}
+
+.showcase_wrapper {
+  flex: 2;
+  position: relative;
+  height: 95vh;
+  overflow: hidden;
+}
+
+.showcase {
+  box-shadow: 0 4px 8px rgb(43, 43, 43);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.questions{
+  flex: 1;
+  height: 95vh;
+  overflow-y: scroll;
+  margin-left:15px;
+  margin-right: 15px;
+}
+
+.selected {
+  background-color: rgb(199, 198, 196);
+  border: 1px #2f2f30 solid;
+}
+.unselected{
+  background-color: #F5F4F3;
+  border: 1px rgb(221, 221, 220) solid;
+}
+
+.question:hover{
+  background-color: rgb(199, 198, 196);
+  box-shadow: 0 4px 8px rgb(43, 43, 43);
+  border-radius: 5px;
+  border: 1px #3c3c3d solid;
+}
+
+.question {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 15px;
+  margin-top: 5px;
+  margin-bottom: 5px;
+  justify-content: flex-start;
+}
+
+.question_title {
+  width: 100%;
+  text-align: left;
+  margin: 5px;
+}
+
+.choices {
+  list-style-type: none;
+  flex-wrap: wrap;
+}
+
+.choice {
+  width: 45%;
+  flex: 1;
+  display: inline-flex;
+  flex-direction: row;
+}
+
+.choices input, label{
+  margin: 5px;
+}
+
+.goto_button{
+  align-self: flex-end;
+  text-align: right;
+  margin-left: auto;
+  border: 1px solid rgb(115, 115, 115);
+  border-radius: 5px;
+  padding: 5px;
+}
+
+.goto_button:hover{
+  cursor: pointer;
+  background-color: rgb(115, 115, 115);
+  color: rgb(221, 221, 220);
+}
+

--- a/packages/training-tags-demo/tsconfig.json
+++ b/packages/training-tags-demo/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "jsx": "react",
+    "baseUrl": ".",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "lib": [
+      "dom", "es2015"
+    ],
+  },
+  "include": [
+    "./*"
+  ]
+}

--- a/packages/training-tags-demo/webpack.config.js
+++ b/packages/training-tags-demo/webpack.config.js
@@ -1,0 +1,40 @@
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+
+module.exports = {
+mode: 'development',
+  entry: './app.ts',
+  output: {
+    filename: 'js/[name].js'
+  },
+  devtool: 'source-map',
+  resolve: {
+    extensions: ['.js', '.jsx', '.json', '.ts', '.tsx']
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(ts|tsx)$/,
+        loader: 'ts-loader'
+      },
+      { enforce: "pre", test: /\.js$/, use: ["source-map-loader"] },
+      {
+        test: /\.css$/i,
+        use: ['style-loader', 'css-loader'],
+      },
+    ]
+  },
+  plugins: [
+    new CleanWebpackPlugin(),
+    new HtmlWebpackPlugin({
+      title: 'Development',
+      template: 'index.html'
+    }),
+  ],
+  devServer: {
+    port: 8000,
+    devMiddleware: {
+      writeToDisk: true
+    }
+  }
+}

--- a/packages/vs-app/src/SceneLoader.ts
+++ b/packages/vs-app/src/SceneLoader.ts
@@ -9,7 +9,7 @@ export class SceneLoader {
 
   /**
    * Load the scene for a given model.
-   * 
+   *
    * @param sid sid of the model, used to lookup the scene.
    * @param callback an optional callback which is called once for scene node created.
    */
@@ -24,8 +24,9 @@ export class SceneLoader {
       return;
     }
 
-    const nodesToStart: ISceneNode[] = await this.sdk.Scene.deserialize(JSON.stringify(scene));
-    
+    const sceneObject = await this.sdk.Scene.deserialize(JSON.stringify(scene));
+    const nodesToStart = [...sceneObject.nodeIterator()];
+
     if (callback) {
       for (const node of nodesToStart) {
         callback(node);


### PR DESCRIPTION
This update updates our SDK Bundle examples to be compatible with Bundle v24.2.1 and THREE.js 0.151.3

We have updated many deprecated THREE.js loaders and methods.  Deserialization of Scene 1.0 data has been handled with compatibility code.

We have also updated the SDK for Embeds Examples to use our TypeScript definitions and replaced use of the Mattertag namespace with the Tag namespace.